### PR TITLE
updated gee_asset_path with another gee account

### DIFF
--- a/computing/clart/clart.py
+++ b/computing/clart/clart.py
@@ -65,7 +65,7 @@ def clart_layer(state, district, block):
             + valid_gee_text(block.lower())
         )
         lithology = ee.Image(
-            GEE_ASSET_PATH
+            "projects/ee-corestackdev/assets/apps/mws/"    ## We have hardcoded because now we are using core-stack-dev1 account for the layer pipeline
             + valid_gee_text(state.lower())
             + "/"
             + valid_gee_text(state.lower())

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -158,13 +158,13 @@ ODK_SYNC_URL_AGRI_FEEDBACK = (
 # MARK: GEE Paths
 GCS_BUCKET_NAME = "core_stack"
 
-GEE_ASSET_PATH = "projects/ee-corestackdev/assets/apps/mws/"
+GEE_ASSET_PATH = "projects/core-stack-dev-2/assets/apps/mws/"
 GEE_HELPER_PATH = "projects/ee-corestack-helper/assets/apps/mws/"
 
-GEE_PATH_PLANTATION = "projects/ee-corestackdev/assets/apps/plantation/"
+GEE_PATH_PLANTATION = "projects/core-stack-dev-2/assets/apps/plantation/"
 GEE_PATH_PLANTATION_HELPER = "projects/ee-corestack-helper/assets/apps/plantation/"
 
-GEE_BASE_PATH = "projects/ee-corestackdev/assets/apps"
+GEE_BASE_PATH = "projects/core-stack-dev-2/assets/apps"
 GEE_HELPER_BASE_PATH = "projects/ee-corestack-helper/assets/apps"
 
 GEE_DATASET_PATH = "projects/corestack-datasets/assets/datasets"

--- a/waterrejuvenation/utils.py
+++ b/waterrejuvenation/utils.py
@@ -6,6 +6,7 @@ from utilities.constants import (
     GEE_PATHS,
     PAN_INDIA_LULC_V3_DATASET,
     WATER_REJ_GEE_ASSET,
+    GEE_ASSET_PATH,
 )
 from utilities.gee_utils import (
     ee_initialize,
@@ -64,7 +65,7 @@ EXPECTED_EXCEL_HEADERS = {
 }
 
 
-def get_filtered_mws_layer_name(project_name, layer_name, project_id="ee-corestackdev"):
+def get_filtered_mws_layer_name(project_name, layer_name, project_id=GEE_ASSET_PATH):
     WATER_REJ_GEE_ASSET = f"projects/{project_id}/assets/apps/waterbody/"
     return (
         WATER_REJ_GEE_ASSET


### PR DESCRIPTION
## Change Logs
1. Update GEE_ASSET_PATH with the **core-stack-dev-2** gee account.
2. Clart is using lithology from ee-corestack account, which is hardcoded. why can be updated accordingly.