### PR TITLE
Feature/stac layerwise

### DIFF
--- a/computing/STAC_specs/stac_collection.py
+++ b/computing/STAC_specs/stac_collection.py
@@ -1,5 +1,3 @@
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
 import datetime
 import logging
 import os
@@ -7,24 +5,25 @@ import re
 import subprocess
 import urllib
 import xml.etree.ElementTree as ET
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
 
-from nrm_app.celery import app
 import pandas as pd
 import pystac
 import requests
-from shapely.geometry import mapping, Polygon
+from shapely.geometry import Polygon, mapping
 
 from computing.STAC_specs import constants
+from nrm_app.celery import app
 from nrm_app.settings import (
     BASE_DIR,
+    GEOSERVER_PASSWORD,
+    GEOSERVER_USERNAME,
     S3_ACCESS_KEY,
     S3_SECRET_KEY,
-    GEOSERVER_USERNAME,
-    GEOSERVER_PASSWORD,
 )
 
 log = logging.getLogger(__name__)
-
 
 
 def sanitize_text(text):
@@ -65,20 +64,29 @@ class STACConfig:
     geoserver_base_url: str = constants.GEOSERVER_BASE_URL
     thumbnail_data_url: str = constants.S3_STAC_BUCKET_URL
     local_data_dir: str = _STAC_DATA
-    stac_files_dir: str = os.path.join(_STAC_DATA, "CorestackCatalogs_merged_collection")
+    stac_files_dir: str = os.path.join(
+        _STAC_DATA, "CorestackCatalogs_merged_collection"
+    )
     thumbnail_dir: str = os.path.join(_STAC_DATA, "STAC_output_merged_collection")
     style_file_dir: str = os.path.join(_STAC_DATA, "input", "style_files")
     tehsil_dirname: str = "tehsil_wise"
     s3_bucket_name: str = constants.S3_STAC_BUCKET_NAME
     s3_uri: str = constants.S3_STAC_URI
-    layer_map_csv: str = os.path.join(_STAC_DATA, "input", "metadata", "layer_mapping.csv")
-    layer_desc_csv: str = os.path.join(_STAC_DATA, "input", "metadata", "layer_descriptions.csv")
-    column_desc_csv: str = os.path.join(_STAC_DATA, "input", "metadata", "vector_column_descriptions.csv")
+    layer_map_csv: str = os.path.join(
+        _STAC_DATA, "input", "metadata", "layer_mapping.csv"
+    )
+    layer_desc_csv: str = os.path.join(
+        _STAC_DATA, "input", "metadata", "layer_descriptions.csv"
+    )
+    column_desc_csv: str = os.path.join(
+        _STAC_DATA, "input", "metadata", "vector_column_descriptions.csv"
+    )
 
 
 # ---------------------------------------------------------------------------
 # GeoServer interaction — metadata only, zero data download
 # ---------------------------------------------------------------------------
+
 
 class GeoServerClient:
     def __init__(self, base_url, username=None, password=None):
@@ -142,7 +150,9 @@ class GeoServerClient:
         if response.status_code != 200:
             log.error(
                 "Raster DescribeCoverage failed [status=%s] url=%s body=%s",
-                response.status_code, describe_url, response.text[:300],
+                response.status_code,
+                describe_url,
+                response.text[:300],
             )
             return None
 
@@ -159,18 +169,24 @@ class GeoServerClient:
         lower = envelope.find("gml:lowerCorner", ns).text.split()
         upper = envelope.find("gml:upperCorner", ns).text.split()
         bbox = [float(lower[1]), float(lower[0]), float(upper[1]), float(upper[0])]
-        footprint = Polygon([
-            [bbox[0], bbox[1]], [bbox[0], bbox[3]],
-            [bbox[2], bbox[3]], [bbox[2], bbox[1]],
-        ])
+        footprint = Polygon(
+            [
+                [bbox[0], bbox[1]],
+                [bbox[0], bbox[3]],
+                [bbox[2], bbox[3]],
+                [bbox[2], bbox[1]],
+            ]
+        )
 
         grid_low = root.find(".//gml:low", ns)
         grid_high = root.find(".//gml:high", ns)
         if grid_low is not None and grid_high is not None:
             low_c = grid_low.text.split()
             high_c = grid_high.text.split()
-            shape = [int(high_c[1]) - int(low_c[1]) + 1,
-                     int(high_c[0]) - int(low_c[0]) + 1]
+            shape = [
+                int(high_c[1]) - int(low_c[1]) + 1,
+                int(high_c[0]) - int(low_c[0]) + 1,
+            ]
         else:
             shape = [0, 0]
 
@@ -189,18 +205,24 @@ class GeoServerClient:
         if response.status_code != 200:
             log.error(
                 "Vector featuretype fetch failed [status=%s] url=%s body=%s",
-                response.status_code, url, response.text[:300],
+                response.status_code,
+                url,
+                response.text[:300],
             )
             return None
 
         ft = response.json()["featureType"]
         ll = ft["latLonBoundingBox"]
         bbox = [ll["minx"], ll["miny"], ll["maxx"], ll["maxy"]]
-        footprint = Polygon([
-            [bbox[0], bbox[1]], [bbox[0], bbox[3]],
-            [bbox[2], bbox[3]], [bbox[2], bbox[1]],
-            [bbox[0], bbox[1]],
-        ])
+        footprint = Polygon(
+            [
+                [bbox[0], bbox[1]],
+                [bbox[0], bbox[3]],
+                [bbox[2], bbox[3]],
+                [bbox[2], bbox[1]],
+                [bbox[0], bbox[1]],
+            ]
+        )
 
         columns = []
         for attr in ft.get("attributes", {}).get("attribute", []):
@@ -224,7 +246,9 @@ class GeoServerClient:
         if response.status_code != 200:
             log.error(
                 "Layer info fetch failed [status=%s] url=%s body=%s",
-                response.status_code, url, response.text[:300],
+                response.status_code,
+                url,
+                response.text[:300],
             )
             return None
 
@@ -243,7 +267,9 @@ class GeoServerClient:
         if response.status_code != 200:
             log.error(
                 "List styles failed [status=%s] url=%s body=%s",
-                response.status_code, url, response.text[:300],
+                response.status_code,
+                url,
+                response.text[:300],
             )
             return []
         styles = response.json().get("styles") or {}
@@ -258,20 +284,27 @@ class GeoServerClient:
         if response.status_code != 200:
             log.error(
                 "Thumbnail download failed [status=%s] content_type=%s url=%s body=%s",
-                response.status_code, content_type, url, response.text[:300],
+                response.status_code,
+                content_type,
+                url,
+                response.text[:300],
             )
             return False
         if "image" not in content_type:
             log.error(
                 "Thumbnail response is not an image [content_type=%s] url=%s body=%s",
-                content_type, url, response.text[:300],
+                content_type,
+                url,
+                response.text[:300],
             )
             return False
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
         with open(output_path, "wb") as f:
             f.write(response.content)
         log.info(
-            "Thumbnail saved [%d bytes] -> %s", len(response.content), output_path,
+            "Thumbnail saved [%d bytes] -> %s",
+            len(response.content),
+            output_path,
         )
         return True
 
@@ -279,6 +312,7 @@ class GeoServerClient:
 # ---------------------------------------------------------------------------
 # Metadata from CSVs
 # ---------------------------------------------------------------------------
+
 
 class MetadataProvider:
     def __init__(self, config):
@@ -298,7 +332,9 @@ class MetadataProvider:
         desc = _clean_csv_value(desc, "")
         return desc if desc else layer_name.replace("_", " ").title()
 
-    def get_layer_mapping(self, layer_name, district, block, start_year="", overwrite_metadata=False):
+    def get_layer_mapping(
+        self, layer_name, district, block, start_year="", overwrite_metadata=False
+    ):
         path = self.config.layer_map_csv
         if os.path.exists(path) and not overwrite_metadata:
             df = pd.read_csv(path)
@@ -313,10 +349,16 @@ class MetadataProvider:
             gs_layer = gs_layer.format(
                 start_year=str(int(start_year) % 100),
                 end_year=str((int(start_year) + 1) % 100),
-                district=district, block=block,
+                district=district,
+                block=block,
             )
-        elif layer_name in ("tree_canopy_cover_density_raster", "tree_canopy_height_raster"):
-            gs_layer = gs_layer.format(start_year=start_year, district=district, block=block)
+        elif layer_name in (
+            "tree_canopy_cover_density_raster",
+            "tree_canopy_height_raster",
+        ):
+            gs_layer = gs_layer.format(
+                start_year=start_year, district=district, block=block
+            )
         else:
             gs_layer = gs_layer.format(district=district, block=block)
 
@@ -347,6 +389,7 @@ class MetadataProvider:
 # ---------------------------------------------------------------------------
 # Style file parsing (raster palette for classification extension)
 # ---------------------------------------------------------------------------
+
 
 class StyleParser:
     def __init__(self, style_file_dir):
@@ -384,6 +427,7 @@ class StyleParser:
 # STAC catalog hierarchy management
 # ---------------------------------------------------------------------------
 
+
 class CatalogManager:
     def __init__(self, config):
         self.config = config
@@ -407,44 +451,70 @@ class CatalogManager:
         return pystac.Provider(
             name="CoRE Stack",
             roles=[
-                pystac.ProviderRole.PRODUCER, pystac.ProviderRole.PROCESSOR,
-                pystac.ProviderRole.HOST, pystac.ProviderRole.LICENSOR,
+                pystac.ProviderRole.PRODUCER,
+                pystac.ProviderRole.PROCESSOR,
+                pystac.ProviderRole.HOST,
+                pystac.ProviderRole.LICENSOR,
             ],
             url="https://core-stack.org/",
         )
 
     def update(self, state, district, block, item):
+        """Update the catalog and return the list of local paths that were written."""
         bbox = item.bbox
-        log.info("Updating catalog: state=%s district=%s block=%s item=%s bbox=%s",
-                 state, district, block, item.id, bbox)
+        log.info(
+            "Updating catalog: state=%s district=%s block=%s item=%s bbox=%s",
+            state,
+            district,
+            block,
+            item.id,
+            bbox,
+        )
 
         block_existed = self._upsert_block(state, district, block, bbox, item)
         if block_existed:
             log.info("Block collection existed; merged item into it")
-            self._expand_extent(self._district_dir(state, district), bbox)
-            self._expand_extent(self._state_dir(state), bbox)
-            return True
+            dist_dir = self._district_dir(state, district)
+            state_dir = self._state_dir(state)
+            self._expand_extent(dist_dir, bbox)
+            self._expand_extent(state_dir, bbox)
+            return [
+                self._block_dir(state, district, block),
+                os.path.join(dist_dir, "collection.json"),
+                os.path.join(state_dir, "collection.json"),
+            ]
 
         block_coll = self._new_block_collection(state, district, block, bbox, item)
 
         district_existed = self._upsert_district(state, district, bbox, block_coll)
         if district_existed:
             log.info("District existed; created new block under it")
-            self._expand_extent(self._state_dir(state), bbox)
-            return True
+            state_dir = self._state_dir(state)
+            self._expand_extent(state_dir, bbox)
+            return [
+                self._district_dir(state, district),
+                os.path.join(state_dir, "collection.json"),
+            ]
 
         district_coll = self._new_district_collection(state, district, bbox, block_coll)
 
         state_existed = self._upsert_state(state, bbox, district_coll)
         if state_existed:
             log.info("State existed; created new district under it")
-            return True
+            return [self._state_dir(state)]
 
         state_coll = self._new_state_collection(state, bbox, district_coll)
         log.info("Created new state collection; updating tehsil and root catalogs")
         self._upsert_tehsil(state_coll)
         self._upsert_root()
-        return True
+        tehsil_dir = os.path.join(
+            self.config.stac_files_dir, self.config.tehsil_dirname
+        )
+        return [
+            self._state_dir(state),
+            os.path.join(tehsil_dir, "catalog.json"),
+            os.path.join(self.config.stac_files_dir, "catalog.json"),
+        ]
 
     def _expand_extent(self, dir_path, bbox):
         path = os.path.join(dir_path, "collection.json")
@@ -460,8 +530,11 @@ class CatalogManager:
 
     def _block_dir(self, state, district, block):
         return os.path.join(
-            self.config.stac_files_dir, self.config.tehsil_dirname,
-            state, district, block,
+            self.config.stac_files_dir,
+            self.config.tehsil_dirname,
+            state,
+            district,
+            block,
         )
 
     def _upsert_block(self, state, district, block, bbox, item):
@@ -484,13 +557,20 @@ class CatalogManager:
         d = self._block_dir(state, district, block)
         os.makedirs(d, exist_ok=True)
         coll = pystac.Collection(
-            id=block, title=block,
+            id=block,
+            title=block,
             description=f"STAC collection for {block} block data in {district}, {state}",
             license="CC-BY-4.0",
             extent=self._default_extent(bbox),
             providers=[self._provider()],
-            keywords=["social-ecological", "sustainability", "CoRE stack",
-                       block, district, state],
+            keywords=[
+                "social-ecological",
+                "sustainability",
+                "CoRE stack",
+                block,
+                district,
+                state,
+            ],
         )
         coll.add_item(item)
         return coll
@@ -499,8 +579,10 @@ class CatalogManager:
 
     def _district_dir(self, state, district):
         return os.path.join(
-            self.config.stac_files_dir, self.config.tehsil_dirname,
-            state, district,
+            self.config.stac_files_dir,
+            self.config.tehsil_dirname,
+            state,
+            district,
         )
 
     def _upsert_district(self, state, district, bbox, block_coll):
@@ -521,13 +603,19 @@ class CatalogManager:
         d = self._district_dir(state, district)
         os.makedirs(d, exist_ok=True)
         coll = pystac.Collection(
-            id=district, title=district,
+            id=district,
+            title=district,
             description=f"STAC collection for data of {district} district",
             license="CC-BY-4.0",
             extent=self._default_extent(bbox),
             providers=[self._provider()],
-            keywords=["social-ecological", "sustainability", "CoRE stack",
-                       district, state],
+            keywords=[
+                "social-ecological",
+                "sustainability",
+                "CoRE stack",
+                district,
+                state,
+            ],
         )
         coll.add_child(block_coll)
         coll.normalize_and_save(d, catalog_type=pystac.CatalogType.SELF_CONTAINED)
@@ -537,7 +625,9 @@ class CatalogManager:
 
     def _state_dir(self, state):
         return os.path.join(
-            self.config.stac_files_dir, self.config.tehsil_dirname, state,
+            self.config.stac_files_dir,
+            self.config.tehsil_dirname,
+            state,
         )
 
     def _upsert_state(self, state, bbox, district_coll):
@@ -558,27 +648,37 @@ class CatalogManager:
         d = self._state_dir(state)
         os.makedirs(d, exist_ok=True)
         coll = pystac.Collection(
-            id=state, title=state,
+            id=state,
+            title=state,
             description=f"STAC Collection for data of {state} state.",
             license="CC-BY-4.0",
             extent=self._default_extent(bbox),
             providers=[self._provider()],
             keywords=["social-ecological", "sustainability", "CoRE stack", state],
         )
-        coll.add_link(pystac.Link(
-            rel=pystac.RelType.LICENSE,
-            target="https://spdx.org/licenses/CC-BY-4.0.html",
-            media_type="text/html",
-        ))
+        coll.add_link(
+            pystac.Link(
+                rel=pystac.RelType.LICENSE,
+                target="https://spdx.org/licenses/CC-BY-4.0.html",
+                media_type="text/html",
+            )
+        )
         for target, title in [
-            ("https://core-stack.org/", "CoRE stack"),
-            ("https://drive.google.com/file/d/1ZxovdpPThkN09cB1TcUYSE2BImI7M3k_/view", "Technical Manual"),
+            ("https://core-stack.org/", "CoRE Stack"),
+            (
+                "https://drive.google.com/file/d/1ZxovdpPThkN09cB1TcUYSE2BImI7M3k_/view",
+                "Technical Manual",
+            ),
             ("https://github.com/orgs/core-stack-org/repositories", "Github link"),
         ]:
-            coll.add_link(pystac.Link(
-                rel="documentation", target=target,
-                title=title, media_type="application/pdf",
-            ))
+            coll.add_link(
+                pystac.Link(
+                    rel="documentation",
+                    target=target,
+                    title=title,
+                    media_type="application/pdf",
+                )
+            )
         coll.add_child(district_coll)
         coll.normalize_and_save(d, catalog_type=pystac.CatalogType.SELF_CONTAINED)
         return coll
@@ -628,6 +728,7 @@ class CatalogManager:
 # S3 sync
 # ---------------------------------------------------------------------------
 
+
 class S3Syncer:
     def __init__(self, access_key, secret_key):
         self.access_key = access_key
@@ -644,26 +745,74 @@ class S3Syncer:
         log.info("S3 sync starting: %s -> %s (cwd=%s)", source, destination, BASE_DIR)
         result = subprocess.run(
             ["aws", "s3", "sync", source, destination],
-            cwd=BASE_DIR, env=env,
-            capture_output=True, text=True,
+            cwd=BASE_DIR,
+            env=env,
+            capture_output=True,
+            text=True,
         )
         if result.returncode == 0:
             log.info(
                 "S3 sync OK: %s -> %s\n%s",
-                source, destination, result.stdout.strip() or "(no changes)",
+                source,
+                destination,
+                result.stdout.strip() or "(no changes)",
             )
         else:
             log.error(
                 "S3 sync FAILED [rc=%s]: %s -> %s\nstdout:\n%s\nstderr:\n%s",
-                result.returncode, source, destination,
-                result.stdout.strip(), result.stderr.strip(),
+                result.returncode,
+                source,
+                destination,
+                result.stdout.strip(),
+                result.stderr.strip(),
             )
         return result.returncode
+
+    def upload_paths(self, paths, s3_uri):
+        """Upload only the given local paths (files or directories) to S3."""
+        env = {
+            **os.environ,
+            "AWS_ACCESS_KEY_ID": self.access_key,
+            "AWS_SECRET_ACCESS_KEY": self.secret_key,
+        }
+        ok = True
+        for path in paths:
+            if not os.path.exists(path):
+                log.warning("S3 upload skipped (does not exist): %s", path)
+                continue
+            rel = os.path.relpath(path, BASE_DIR)
+            if os.path.isdir(path):
+                dest = s3_uri + rel + "/"
+                cmd = ["aws", "s3", "sync", rel, dest]
+            else:
+                dest = s3_uri + rel
+                cmd = ["aws", "s3", "cp", rel, dest]
+            log.info("S3 upload: %s -> %s", rel, dest)
+            result = subprocess.run(
+                cmd, cwd=BASE_DIR, env=env, capture_output=True, text=True
+            )
+            if result.returncode == 0:
+                log.info(
+                    "S3 upload OK: %s\n%s",
+                    dest,
+                    result.stdout.strip() or "(no changes)",
+                )
+            else:
+                log.error(
+                    "S3 upload FAILED [rc=%s]: %s\nstdout:\n%s\nstderr:\n%s",
+                    result.returncode,
+                    dest,
+                    result.stdout.strip(),
+                    result.stderr.strip(),
+                )
+                ok = False
+        return ok
 
 
 # ---------------------------------------------------------------------------
 # STAC item builders (template method pattern)
 # ---------------------------------------------------------------------------
+
 
 class BaseSTACItemBuilder(ABC):
     def __init__(self, config, geoserver, metadata, style_parser):
@@ -674,67 +823,92 @@ class BaseSTACItemBuilder(ABC):
         self._ws = None
         self._gs_layer = None
 
-    def build(self, state, district, block, layer_name, overwrite=False,
-              overwrite_metadata=False, **kwargs):
+    def build(
+        self,
+        state,
+        district,
+        block,
+        layer_name,
+        overwrite=False,
+        overwrite_metadata=False,
+        **kwargs,
+    ):
         log.info(
             "Building STAC item: state=%s district=%s block=%s layer=%s kwargs=%s",
-            state, district, block, layer_name, kwargs,
+            state,
+            district,
+            block,
+            layer_name,
+            kwargs,
         )
-        description = self.metadata.get_layer_description(layer_name, overwrite_metadata)
+        description = self.metadata.get_layer_description(
+            layer_name, overwrite_metadata
+        )
         layer_map = self.metadata.get_layer_mapping(
-            layer_name, district, block, kwargs.get("start_year", ""),
+            layer_name,
+            district,
+            block,
+            kwargs.get("start_year", ""),
             overwrite_metadata=overwrite_metadata,
         )
         log.debug("Resolved layer_map: %s", layer_map)
-        item = self._create_item(state, district, block, layer_name,
-                                 description, layer_map, **kwargs)
+        item = self._create_item(
+            state, district, block, layer_name, description, layer_map, **kwargs
+        )
         if item is None:
             log.error("Item creation returned None for layer=%s", layer_name)
             return None
         item = self._add_data_asset(item, layer_map)
-        item = self._add_extensions(item, layer_map, overwrite_metadata=overwrite_metadata,
-                                    **kwargs)
+        item = self._add_extensions(
+            item, layer_map, overwrite_metadata=overwrite_metadata, **kwargs
+        )
         self._add_style_asset(item, layer_map)
-        item = self._add_thumbnail(item, state, district, block,
-                                   layer_name, layer_map, **kwargs)
+        item = self._add_thumbnail(
+            item, state, district, block, layer_name, layer_map, **kwargs
+        )
         log.info(
             "Built STAC item id=%s assets=%s bbox=%s",
-            item.id, list(item.assets.keys()), item.bbox,
+            item.id,
+            list(item.assets.keys()),
+            item.bbox,
         )
         return item
 
     @abstractmethod
-    def _create_item(self, state, district, block, layer_name,
-                     description, layer_map, **kw):
-        ...
+    def _create_item(
+        self, state, district, block, layer_name, description, layer_map, **kw
+    ): ...
 
     @abstractmethod
-    def _add_data_asset(self, item, layer_map):
-        ...
+    def _add_data_asset(self, item, layer_map): ...
 
     @abstractmethod
-    def _add_extensions(self, item, layer_map, **kw):
-        ...
+    def _add_extensions(self, item, layer_map, **kw): ...
 
-    def _add_thumbnail(self, item, state, district, block,
-                       layer_name, layer_map, **kw):
+    def _add_thumbnail(self, item, state, district, block, layer_name, layer_map, **kw):
         start_year = kw.get("start_year", "")
         fname = self._thumbnail_filename(state, district, block, layer_name, start_year)
         path = os.path.join(self.config.thumbnail_dir, fname)
         style = self.geoserver.fetch_layer_default_style(self._ws, self._gs_layer) or ""
         url = self.geoserver.wms_thumbnail_url(
-            self._ws, self._gs_layer, item.bbox, style=style,
+            self._ws,
+            self._gs_layer,
+            item.bbox,
+            style=style,
         )
         if self.geoserver.download_thumbnail(url, path):
             self._add_thumbnail_asset(item, path)
             log.info(
                 "Thumbnail asset attached to item=%s style=%s href=%s",
-                item.id, style or "(WMS default)", item.assets["thumbnail"].href,
+                item.id,
+                style or "(WMS default)",
+                item.assets["thumbnail"].href,
             )
         else:
             log.warning(
                 "Skipping thumbnail asset for item=%s (download failed). url=%s",
-                item.id, url,
+                item.id,
+                url,
             )
         return item
 
@@ -788,17 +962,21 @@ class BaseSTACItemBuilder(ABC):
 
 
 class RasterSTACItemBuilder(BaseSTACItemBuilder):
-
-    def _create_item(self, state, district, block, layer_name,
-                     description, layer_map, **kw):
+    def _create_item(
+        self, state, district, block, layer_name, description, layer_map, **kw
+    ):
         start_year = kw.get("start_year", "")
         ws, gs_layer = layer_map["workspace"], layer_map["layer_name"]
 
         desc_url = self.geoserver.raster_describe_url(ws, gs_layer)
         meta = self.geoserver.fetch_raster_metadata(desc_url)
         if meta is None:
-            log.error("Could not fetch raster metadata for layer=%s ws=%s gs_layer=%s",
-                      layer_name, ws, gs_layer)
+            log.error(
+                "Could not fetch raster metadata for layer=%s ws=%s gs_layer=%s",
+                layer_name,
+                ws,
+                gs_layer,
+            )
             return None
 
         bbox, footprint, crs, shape = meta
@@ -813,16 +991,21 @@ class RasterSTACItemBuilder(BaseSTACItemBuilder):
         }
         if start_year:
             sd = pd.to_datetime(f"{start_year}-{constants.AGRI_YEAR_START_DATE}")
-            ed = pd.to_datetime(f"{int(start_year)+1}-{constants.AGRI_YEAR_END_DATE}")
+            ed = pd.to_datetime(f"{int(start_year) + 1}-{constants.AGRI_YEAR_END_DATE}")
             props["start_datetime"] = sd.isoformat() + "Z"
             props["end_datetime"] = ed.isoformat() + "Z"
         else:
-            props["start_datetime"] = constants.DEFAULT_START_DATE.strftime("%Y-%m-%dT%H:%M:%SZ")
-            props["end_datetime"] = constants.DEFAULT_END_DATE.strftime("%Y-%m-%dT%H:%M:%SZ")
+            props["start_datetime"] = constants.DEFAULT_START_DATE.strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+            props["end_datetime"] = constants.DEFAULT_END_DATE.strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
 
         item = pystac.Item(
             id=self._item_id(state, district, block, layer_name, start_year),
-            geometry=footprint, bbox=bbox,
+            geometry=footprint,
+            bbox=bbox,
             datetime=datetime.datetime.now(datetime.timezone.utc),
             properties=props,
         )
@@ -835,16 +1018,24 @@ class RasterSTACItemBuilder(BaseSTACItemBuilder):
         return item
 
     def _add_data_asset(self, item, layer_map):
-        url = self.geoserver.raster_data_url(layer_map["workspace"], layer_map["layer_name"])
+        url = self.geoserver.raster_data_url(
+            layer_map["workspace"], layer_map["layer_name"]
+        )
         item.add_asset(
             "data",
-            pystac.Asset(href=url, media_type=pystac.MediaType.GEOTIFF,
-                         roles=["data"], title="Raster Layer"),
+            pystac.Asset(
+                href=url,
+                media_type=pystac.MediaType.GEOTIFF,
+                roles=["data"],
+                title="Raster Layer",
+            ),
         )
         return item
 
     def _add_extensions(self, item, layer_map, **kw):
-        style_classes = self.style_parser.parse_raster_style(layer_map["style_file_url"])
+        style_classes = self.style_parser.parse_raster_style(
+            layer_map["style_file_url"]
+        )
         cls_ext = pystac.extensions.classification.ClassificationExtension.ext(
             item.assets["data"], add_if_missing=True
         )
@@ -861,15 +1052,19 @@ class RasterSTACItemBuilder(BaseSTACItemBuilder):
 
 
 class VectorSTACItemBuilder(BaseSTACItemBuilder):
-
-    def _create_item(self, state, district, block, layer_name,
-                     description, layer_map, **kw):
+    def _create_item(
+        self, state, district, block, layer_name, description, layer_map, **kw
+    ):
         ws, gs_layer = layer_map["workspace"], layer_map["layer_name"]
 
         meta = self.geoserver.fetch_vector_metadata(ws, gs_layer)
         if meta is None:
-            log.error("Could not fetch vector metadata for layer=%s ws=%s gs_layer=%s",
-                      layer_name, ws, gs_layer)
+            log.error(
+                "Could not fetch vector metadata for layer=%s ws=%s gs_layer=%s",
+                layer_name,
+                ws,
+                gs_layer,
+            )
             return None
 
         bbox, footprint, columns = meta
@@ -879,30 +1074,42 @@ class VectorSTACItemBuilder(BaseSTACItemBuilder):
 
         item = pystac.Item(
             id=self._item_id(state, district, block, layer_name),
-            geometry=footprint, bbox=bbox,
+            geometry=footprint,
+            bbox=bbox,
             datetime=datetime.datetime.now(datetime.timezone.utc),
             properties={
                 "title": layer_map["display_name"],
                 "description": description,
-                "start_datetime": constants.DEFAULT_START_DATE.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "end_datetime": constants.DEFAULT_END_DATE.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "start_datetime": constants.DEFAULT_START_DATE.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                ),
+                "end_datetime": constants.DEFAULT_END_DATE.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                ),
                 "keywords": [t for t in [layer_map["theme"]] if t],
             },
         )
         return item
 
     def _add_data_asset(self, item, layer_map):
-        url = self.geoserver.vector_data_url(layer_map["workspace"], layer_map["layer_name"])
+        url = self.geoserver.vector_data_url(
+            layer_map["workspace"], layer_map["layer_name"]
+        )
         item.add_asset(
             "data",
-            pystac.Asset(href=url, media_type=pystac.MediaType.GEOJSON,
-                         roles=["data"], title="Vector Layer"),
+            pystac.Asset(
+                href=url,
+                media_type=pystac.MediaType.GEOJSON,
+                roles=["data"],
+                title="Vector Layer",
+            ),
         )
         return item
 
     def _add_extensions(self, item, layer_map, **kw):
         col_desc = self.metadata.get_vector_column_descriptions(
-            layer_map["ee_layer_name"], kw.get("overwrite_metadata", False),
+            layer_map["ee_layer_name"],
+            kw.get("overwrite_metadata", False),
         )
         desc_map = {
             k: _clean_csv_value(v, "")
@@ -925,6 +1132,7 @@ class VectorSTACItemBuilder(BaseSTACItemBuilder):
 # Top-level orchestrator
 # ---------------------------------------------------------------------------
 
+
 class STACCollectionGenerator:
     def __init__(self, config=None):
         self.config = config or STACConfig()
@@ -941,16 +1149,34 @@ class STACCollectionGenerator:
     def _builder_args(self):
         return (self.config, self.geoserver, self.metadata, self.style_parser)
 
-    def generate_raster(self, state, district, block, layer_name,
-                        start_year="", end_year="", upload_to_s3=False,
-                        overwrite=False, overwrite_metadata=False):
+    def generate_raster(
+        self,
+        state,
+        district,
+        block,
+        layer_name,
+        start_year="",
+        end_year="",
+        upload_to_s3=False,
+        overwrite=False,
+        overwrite_metadata=False,
+    ):
         log.info(
             "generate_raster start: state=%s district=%s block=%s layer=%s "
             "start_year=%s end_year=%s upload_to_s3=%s overwrite=%s overwrite_metadata=%s",
-            state, district, block, layer_name, start_year, end_year,
-            upload_to_s3, overwrite, overwrite_metadata,
+            state,
+            district,
+            block,
+            layer_name,
+            start_year,
+            end_year,
+            upload_to_s3,
+            overwrite,
+            overwrite_metadata,
         )
-        state, district, block = (sanitize_text(x.lower()) for x in (state, district, block))
+        state, district, block = (
+            sanitize_text(x.lower()) for x in (state, district, block)
+        )
         builder = RasterSTACItemBuilder(*self._builder_args())
 
         if start_year and end_year:
@@ -959,14 +1185,33 @@ class STACCollectionGenerator:
             years = [start_year]
 
         built = []
+        s3_paths = set()
         for year in years:
-            item = builder.build(state, district, block, layer_name,
-                                 overwrite=overwrite, overwrite_metadata=overwrite_metadata,
-                                 start_year=year)
+            item = builder.build(
+                state,
+                district,
+                block,
+                layer_name,
+                overwrite=overwrite,
+                overwrite_metadata=overwrite_metadata,
+                start_year=year,
+            )
             if item is None:
-                log.error("generate_raster aborted: item not built for layer=%s year=%s", layer_name, year)
+                log.error(
+                    "generate_raster aborted: item not built for layer=%s year=%s",
+                    layer_name,
+                    year,
+                )
                 continue
-            self.catalog_mgr.update(state, district, block, item)
+            touched = self.catalog_mgr.update(state, district, block, item)
+            if upload_to_s3:
+                s3_paths.update(touched)
+                thumb_fname = BaseSTACItemBuilder._thumbnail_filename(
+                    state, district, block, layer_name, year
+                )
+                thumb_path = os.path.join(self.config.thumbnail_dir, thumb_fname)
+                if os.path.exists(thumb_path):
+                    s3_paths.add(thumb_path)
             log.info("generate_raster built item=%s", item.id)
             built.append(item.id)
 
@@ -975,37 +1220,74 @@ class STACCollectionGenerator:
             return False
 
         if upload_to_s3:
-            self._sync_s3()
+            self._sync_s3(paths=list(s3_paths))
         else:
             log.info("Skipping S3 sync (upload_to_s3=False)")
         log.info("generate_raster done: built %d item(s)=%s", len(built), built)
         return True
 
-    def generate_vector(self, state, district, block, layer_name,
-                        upload_to_s3=False, overwrite=False, overwrite_metadata=False):
+    def generate_vector(
+        self,
+        state,
+        district,
+        block,
+        layer_name,
+        upload_to_s3=False,
+        overwrite=False,
+        overwrite_metadata=False,
+    ):
         log.info(
             "generate_vector start: state=%s district=%s block=%s layer=%s "
             "upload_to_s3=%s overwrite=%s overwrite_metadata=%s",
-            state, district, block, layer_name,
-            upload_to_s3, overwrite, overwrite_metadata,
+            state,
+            district,
+            block,
+            layer_name,
+            upload_to_s3,
+            overwrite,
+            overwrite_metadata,
         )
-        state, district, block = (sanitize_text(x.lower()) for x in (state, district, block))
+        state, district, block = (
+            sanitize_text(x.lower()) for x in (state, district, block)
+        )
         builder = VectorSTACItemBuilder(*self._builder_args())
-        item = builder.build(state, district, block, layer_name,
-                             overwrite=overwrite, overwrite_metadata=overwrite_metadata)
+        item = builder.build(
+            state,
+            district,
+            block,
+            layer_name,
+            overwrite=overwrite,
+            overwrite_metadata=overwrite_metadata,
+        )
         if item is None:
-            log.error("generate_vector aborted: item not built for layer=%s", layer_name)
+            log.error(
+                "generate_vector aborted: item not built for layer=%s", layer_name
+            )
             return False
-        self.catalog_mgr.update(state, district, block, item)
+        touched = self.catalog_mgr.update(state, district, block, item)
         if upload_to_s3:
-            self._sync_s3()
+            s3_paths = set(touched)
+            thumb_fname = BaseSTACItemBuilder._thumbnail_filename(
+                state, district, block, layer_name
+            )
+            thumb_path = os.path.join(self.config.thumbnail_dir, thumb_fname)
+            if os.path.exists(thumb_path):
+                s3_paths.add(thumb_path)
+            self._sync_s3(paths=list(s3_paths))
         else:
             log.info("Skipping S3 sync (upload_to_s3=False)")
         log.info("generate_vector done: item=%s", item.id)
         return True
 
-    def _sync_s3(self):
-        log.info("Starting S3 sync of STAC catalog and thumbnails to %s", self.config.s3_uri)
+    def _sync_s3(self, paths=None):
+        if paths:
+            log.info(
+                "Targeted S3 upload of %d path(s) to %s", len(paths), self.config.s3_uri
+            )
+            return self.s3_syncer.upload_paths(paths, self.config.s3_uri)
+        log.info(
+            "Full S3 sync of STAC catalog and thumbnails to %s", self.config.s3_uri
+        )
         rc_catalog = self.s3_syncer.sync(self.config.stac_files_dir, self.config.s3_uri)
         rc_thumbs = self.s3_syncer.sync(self.config.thumbnail_dir, self.config.s3_uri)
         if rc_catalog == 0 and rc_thumbs == 0:
@@ -1013,7 +1295,8 @@ class STACCollectionGenerator:
         else:
             log.error(
                 "S3 sync incomplete: catalog_rc=%s thumbnails_rc=%s",
-                rc_catalog, rc_thumbs,
+                rc_catalog,
+                rc_thumbs,
             )
         return rc_catalog == 0 and rc_thumbs == 0
 

--- a/computing/STAC_specs/stac_collection.py
+++ b/computing/STAC_specs/stac_collection.py
@@ -1319,10 +1319,11 @@ def generate_stac_collection_task(
     upload_to_s3=False,
     overwrite=False,
     overwrite_metadata=False,
+    layer_id=None,
 ):
     generator = STACCollectionGenerator()
     if layer_type == "raster":
-        return generator.generate_raster(
+        result = generator.generate_raster(
             state,
             district,
             block,
@@ -1333,8 +1334,8 @@ def generate_stac_collection_task(
             overwrite=overwrite,
             overwrite_metadata=overwrite_metadata,
         )
-    if layer_type == "vector":
-        return generator.generate_vector(
+    elif layer_type == "vector":
+        result = generator.generate_vector(
             state,
             district,
             block,
@@ -1343,4 +1344,24 @@ def generate_stac_collection_task(
             overwrite=overwrite,
             overwrite_metadata=overwrite_metadata,
         )
-    raise ValueError(f"Unknown layer_type: {layer_type}")
+    else:
+        raise ValueError(f"Unknown layer_type: {layer_type}")
+
+    if result and layer_id:
+        _mark_layer_stac_generated(layer_id)
+
+    return result
+
+
+def _mark_layer_stac_generated(layer_id):
+    """Flip `Layer.is_stac_specs_generated=True` without re-firing the trigger signal.
+
+    Uses queryset `.update()` so `post_save` is NOT invoked (avoiding any
+    redundant re-dispatch from the auto-trigger handler).
+    """
+    try:
+        from computing.models import Layer
+
+        Layer.objects.filter(id=layer_id).update(is_stac_specs_generated=True)
+    except Exception as exc:  # noqa: BLE001
+        log.error("Failed to mark layer id=%s as STAC-generated: %s", layer_id, exc)

--- a/computing/admin.py
+++ b/computing/admin.py
@@ -35,7 +35,67 @@ class LayerAdmin(admin.ModelAdmin):
 
 
 @admin.register(Dataset)
-class LayerAdmin(admin.ModelAdmin):
+class DatasetAdmin(admin.ModelAdmin):
     search_fields = ("name",)
     list_display = ["name", "layer_type", "workspace"]
     list_filter = ["layer_type"]
+
+
+@admin.register(LayerMapping)
+class LayerMappingAdmin(admin.ModelAdmin):
+    readonly_fields = ("created_at", "updated_at")
+    search_fields = (
+        "layer_name",
+        "db_dataset_name",
+        "ee_layer_name",
+        "geoserver_layer_name",
+        "display_name",
+    )
+    list_display = [
+        "layer_name",
+        "layer_type",
+        "db_dataset_name",
+        "ee_layer_name",
+        "geoserver_workspace_name",
+        "geoserver_layer_name",
+        "auto_stac",
+    ]
+    list_filter = ["layer_type", "auto_stac", "geoserver_workspace_name", "theme"]
+    list_editable = ["auto_stac"]
+    fieldsets = (
+        (
+            "Identity",
+            {
+                "fields": (
+                    "display_name",
+                    "layer_type",
+                    "layer_name",
+                    "theme",
+                )
+            },
+        ),
+        (
+            "Source / GeoServer",
+            {
+                "fields": (
+                    "db_dataset_name",
+                    "ee_layer_name",
+                    "geoserver_workspace_name",
+                    "geoserver_layer_name",
+                    "spatial_resolution_in_meters",
+                )
+            },
+        ),
+        (
+            "STAC trigger",
+            {
+                "fields": (
+                    "auto_stac",
+                    "start_year",
+                    "end_year",
+                    "style_file_url",
+                )
+            },
+        ),
+        ("Audit", {"fields": ("created_at", "updated_at")}),
+    )

--- a/computing/apps.py
+++ b/computing/apps.py
@@ -6,4 +6,5 @@ class ComputingConfig(AppConfig):
     name = "computing"
 
     def ready(self):
-        import computing.tasks
+        import computing.tasks  # noqa: F401  (task autodiscovery)
+        import computing.signals  # noqa: F401  (post_save -> auto STAC trigger)

--- a/computing/change_detection/change_detection.py
+++ b/computing/change_detection/change_detection.py
@@ -13,7 +13,6 @@ from utilities.gee_utils import (
 )
 from nrm_app.celery import app
 from computing.utils import save_layer_info_to_db, update_layer_sync_status
-from computing.STAC_specs import generate_STAC_layerwise
 
 
 @app.task(bind=True)
@@ -463,14 +462,6 @@ def sync_to_gcs_geoserver(
 ):
     task_list = []
 
-    stac_spec_layer_name_dict = {
-        "Urbanization": "change_urbanization_raster",
-        "Degradation": "change_cropping_reduction_raster",
-        "Deforestation": "change_tree_cover_loss_raster",
-        "Afforestation": "change_tree_cover_gain_raster",
-        "CropIntensity": "change_cropping_intensity_raster",
-    }
-
     for change in param_list:
         image = ee.Image(
             get_gee_asset_path(state, district, block)
@@ -492,21 +483,10 @@ def sync_to_gcs_geoserver(
             change.lower(),
         )
         if res and layer_ids[change]:
-            # update flag in db whether layer sync to geoserver or not
             sync_status = update_layer_sync_status(
                 layer_id=layer_ids[change], sync_to_geoserver=True
             )
             print("sync to geoserver flag updated")
-
-            layer_name = stac_spec_layer_name_dict[change]
-            layer_STAC_generated = False
-            layer_STAC_generated = generate_STAC_layerwise.generate_raster_stac(
-                state=state, district=district, block=block, layer_name=layer_name
-            )
-            update_layer_sync_status(
-                layer_id=layer_ids[change], is_stac_specs_generated=layer_STAC_generated
-            )
-
             if sync_status:
                 layer_at_geoserver.append(sync_status)
 

--- a/computing/change_detection/change_detection_vector.py
+++ b/computing/change_detection/change_detection_vector.py
@@ -15,8 +15,6 @@ from utilities.gee_utils import (
 )
 from nrm_app.celery import app
 
-# from computing.STAC_specs import generate_STAC_layerwise
-
 
 @app.task(bind=True)
 def vectorise_change_detection(
@@ -237,15 +235,7 @@ def sync_change_to_geoserver(block, district, state, asset_id, param, layer_id):
 
     if res["status_code"] == 201 and layer_id:
 
-        # update flag in db whether layer sync to geoserver or not
         update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
         print("sync to geoserver flag updated")
-
-        # layer_name = stac_spec_layer_name_dict[param]
-        # layer_STAC_generated = False
-        # layer_STAC_generated = generate_STAC_layerwise.generate_vector_stac(
-        #     state=state, district=district, block=block, layer_name=layer_name
-        # )
-        # update_layer_sync_status(layer_id=layer_id, is_stac_specs_generated=True)
         return True
     return False

--- a/computing/clart/clart.py
+++ b/computing/clart/clart.py
@@ -21,8 +21,6 @@ from .drainage_density import drainage_density
 from .lithology import generate_lithology_layer
 from computing.utils import save_layer_info_to_db, update_layer_sync_status
 
-from computing.STAC_specs import generate_STAC_layerwise
-
 
 @app.task(bind=True)
 def generate_clart_layer(self, state, district, block, gee_account_id):
@@ -251,18 +249,7 @@ def clart_layer(state, district, block):
 
         res = sync_raster_gcs_to_geoserver("clart", layer_name, layer_name, "testClart")
         if res and layer_id:
-
-            # update flag in db whether layer sync to geoserver or not
             update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
             print("sync to geoserver flag updated")
-
-            layer_STAC_generated = False
-            layer_STAC_generated = generate_STAC_layerwise.generate_raster_stac(
-                state=state, district=district, block=block, layer_name="clart_raster"
-            )
-            update_layer_sync_status(
-                layer_id=layer_id, is_stac_specs_generated=layer_STAC_generated
-            )
-
             layer_at_geoserver = True
     return layer_at_geoserver

--- a/computing/cropping_intensity/cropping_intensity.py
+++ b/computing/cropping_intensity/cropping_intensity.py
@@ -22,7 +22,6 @@ from nrm_app.celery import app
 from utilities.geoserver_utils import Geoserver
 from dataclasses import dataclass
 from typing import Optional
-from computing.STAC_specs import generate_STAC_layerwise
 
 geo = Geoserver()
 
@@ -371,17 +370,6 @@ def save_to_db_and_sync_to_geoserver(
     ):  # TODO currently saving info to DB for block level layers only, make changes to accommodate all
         update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
         print("sync to geoserver flag updated")
-
-        layer_STAC_generated = False
-        layer_STAC_generated = generate_STAC_layerwise.generate_vector_stac(
-            state=state,
-            district=district,
-            block=block,
-            layer_name="cropping_intensity_vector",
-        )
-        update_layer_sync_status(
-            layer_id=layer_id, is_stac_specs_generated=layer_STAC_generated
-        )
         layer_at_geoserver = True
     return layer_at_geoserver
 

--- a/computing/drought/drought.py
+++ b/computing/drought/drought.py
@@ -20,7 +20,6 @@ from .merge_layers import (
     merge_yearly_layers,
 )
 from nrm_app.celery import app
-from computing.STAC_specs import generate_STAC_layerwise
 
 
 @app.task(bind=True)
@@ -192,21 +191,9 @@ def push_to_geoserver_db_stc(
         res = sync_fc_to_geoserver(fc, state, layer_name, "drought")
         print(res)
         if res["status_code"] == 201 and layer_id:
-            # update flag in db whether layer sync to geoserver or not
             update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
             print("sync to geoserver flag updated")
             layer_at_geoserver = True
-
-            layer_STAC_generated = False
-            layer_STAC_generated = generate_STAC_layerwise.generate_vector_stac(
-                state=state,
-                district=district,
-                block=block,
-                layer_name="drought_frequency_vector",
-            )  # we only intend to run
-            # stac for drought frequency as it has style file. so please double check
-            # if this data is only of drought frequency and not additionally containing
-            # drought causalty data
     return layer_at_geoserver
 
 

--- a/computing/lulc/lulc_v3.py
+++ b/computing/lulc/lulc_v3.py
@@ -26,7 +26,6 @@ from computing.utils import (
     get_layer_object,
 )
 
-from computing.STAC_specs import generate_STAC_layerwise
 from utilities.constants import PAN_INDIA_RIVER_BASIN_LULC_V3_BASE_PATH
 
 
@@ -269,27 +268,6 @@ def sync_lulc_to_geoserver(
             )
             if res and layer_ids:
                 update_layer_sync_status(layer_id=layer_ids[i], sync_to_geoserver=True)
-                print("STAC: Name array check", name_arr[1])
-
-                if workspace == "LULC_level_3":
-                    start_year_STAC = "20" + str(
-                        s_year
-                    )  # TODO: these are temp fixes, based on current implementations of the pipelines
-
-                    if state_name and block_name and district_name:
-                        layer_STAC_generated = (
-                            generate_STAC_layerwise.generate_raster_stac(
-                                state=state_name,
-                                district=district_name,
-                                block=block_name,
-                                layer_name="land_use_land_cover_raster",
-                                start_year=str(start_year_STAC),
-                            )
-                        )
-                        update_layer_sync_status(
-                            layer_id=layer_ids[i],
-                            is_stac_specs_generated=layer_STAC_generated,
-                        )
                 print("geoserver flag is updated")
                 layer_at_geoserver = True
     return layer_at_geoserver

--- a/computing/lulc/lulc_vector.py
+++ b/computing/lulc/lulc_vector.py
@@ -218,18 +218,6 @@ def sync_to_db_and_geoserver(
         if res["status_code"] == 201 and layer_id:
             update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
             print("sync to geoserver flag updated")
-
-            # stac specs generation block
-            # layer_STAC_generated = False
-            # layer_STAC_generated = generate_STAC_layerwise.generate_vector_stac(
-            #     state=state,
-            #     district=district,
-            #     block=block,
-            #     layer_name='land_use_land_cover_vector')
-
-            # update_layer_sync_status(layer_id=layer_id,
-            #                      is_stac_specs_generated=layer_STAC_generated)
-
             layer_at_geoserver = True
 
         return layer_at_geoserver

--- a/computing/management/commands/load_layer_mappings.py
+++ b/computing/management/commands/load_layer_mappings.py
@@ -1,0 +1,140 @@
+import csv
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from computing.models import LayerMapping
+
+
+DEFAULT_CSV = (
+    Path(settings.BASE_DIR)
+    / "data"
+    / "STAC_specs"
+    / "input"
+    / "metadata"
+    / "layer_mapping.csv"
+)
+
+_REQUIRED_FIELDS = ("layer_name", "layer_type", "db_dataset_name")
+_KNOWN_LAYER_TYPES = {"raster", "vector", "point", "custom"}
+
+
+class Command(BaseCommand):
+    help = (
+        "Load / upsert STAC layer mappings from "
+        "data/STAC_specs/input/metadata/layer_mapping.csv into the LayerMapping table."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--csv",
+            default=str(DEFAULT_CSV),
+            help="Path to layer_mapping.csv (defaults to the in-repo file).",
+        )
+        parser.add_argument(
+            "--prune",
+            action="store_true",
+            help="Delete LayerMapping rows that are not present in the CSV.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Parse the CSV and report what would change, without writing.",
+        )
+
+    def handle(self, *args, **options):
+        csv_path = Path(options["csv"]).expanduser().resolve()
+        if not csv_path.is_file():
+            raise CommandError(f"CSV not found: {csv_path}")
+
+        rows = list(self._iter_valid_rows(csv_path))
+        if not rows:
+            raise CommandError(f"No valid rows found in {csv_path}")
+
+        self.stdout.write(f"Parsed {len(rows)} valid rows from {csv_path}")
+
+        if options["dry_run"]:
+            for r in rows:
+                self.stdout.write(
+                    f"  would upsert: {r['layer_name']} "
+                    f"({r['layer_type']}, ee={r['ee_layer_name'] or '-'})"
+                )
+            return
+
+        created, updated = 0, 0
+        seen_keys = set()
+        with transaction.atomic():
+            for row in rows:
+                key = (row["layer_name"], row["layer_type"], row["ee_layer_name"])
+                seen_keys.add(key)
+                _, was_created = LayerMapping.objects.update_or_create(
+                    layer_name=row["layer_name"],
+                    layer_type=row["layer_type"],
+                    ee_layer_name=row["ee_layer_name"],
+                    defaults={
+                        "display_name": row["display_name"],
+                        "spatial_resolution_in_meters": row[
+                            "spatial_resolution_in_meters"
+                        ],
+                        "db_dataset_name": row["db_dataset_name"],
+                        "geoserver_workspace_name": row["geoserver_workspace_name"],
+                        "geoserver_layer_name": row["geoserver_layer_name"],
+                        "start_year": row["start_year"],
+                        "end_year": row["end_year"],
+                        "style_file_url": row["style_file_url"],
+                        "theme": row["theme"],
+                    },
+                )
+                if was_created:
+                    created += 1
+                else:
+                    updated += 1
+
+            pruned = 0
+            if options["prune"]:
+                qs = LayerMapping.objects.all()
+                stale = [
+                    m
+                    for m in qs
+                    if (m.layer_name, m.layer_type, m.ee_layer_name) not in seen_keys
+                ]
+                pruned = len(stale)
+                for m in stale:
+                    m.delete()
+
+        msg = f"LayerMapping load: created={created} updated={updated}"
+        if options["prune"]:
+            msg += f" pruned={pruned}"
+        self.stdout.write(self.style.SUCCESS(msg))
+
+    @staticmethod
+    def _iter_valid_rows(csv_path):
+        with csv_path.open(newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for raw in reader:
+                row = {k: (v or "").strip() for k, v in raw.items()}
+                if any(not row.get(f) for f in _REQUIRED_FIELDS):
+                    continue
+                if row["layer_type"] not in _KNOWN_LAYER_TYPES:
+                    continue
+                spatial = row.get("spatial_resolution_in_meters") or ""
+                try:
+                    spatial_val = float(spatial) if spatial else None
+                except ValueError:
+                    spatial_val = None
+                yield {
+                    "display_name": row.get("display_name", ""),
+                    "layer_type": row["layer_type"],
+                    "layer_name": row["layer_name"],
+                    "spatial_resolution_in_meters": spatial_val,
+                    "ee_layer_name": row.get("ee_layer_name", ""),
+                    "db_dataset_name": row["db_dataset_name"],
+                    "geoserver_workspace_name": row.get("geoserver_workspace_name", ""),
+                    "geoserver_layer_name": row.get("geoserver_layer_name", ""),
+                    "start_year": row.get("start_year", ""),
+                    "end_year": row.get("end_year", ""),
+                    "style_file_url": row.get("style_file_url", ""),
+                    "theme": row.get("theme", ""),
+                }

--- a/computing/misc/admin_boundary.py
+++ b/computing/misc/admin_boundary.py
@@ -24,8 +24,6 @@ from utilities.constants import (
 )
 from computing.utils import save_layer_info_to_db, update_layer_sync_status
 
-from computing.STAC_specs import generate_STAC_layerwise
-
 
 @app.task(bind=True)
 def generate_tehsil_shape_file_data(self, state, district, block, gee_account_id):
@@ -74,18 +72,6 @@ def generate_tehsil_shape_file_data(self, state, district, block, gee_account_id
     if res["status_code"] == 201 and layer_id:
         update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
         print("sync to geoserver flag updated")
-
-        layer_STAC_generated = False
-        layer_STAC_generated = generate_STAC_layerwise.generate_vector_stac(
-            state=state,
-            district=district,
-            block=block,
-            layer_name="admin_boundaries_vector",
-        )
-        update_layer_sync_status(
-            layer_id=layer_id, is_stac_specs_generated=layer_STAC_generated
-        )
-
         layer_at_geoserver = True
     return layer_at_geoserver
 

--- a/computing/misc/aquifer_vector.py
+++ b/computing/misc/aquifer_vector.py
@@ -15,9 +15,6 @@ from computing.utils import (
     save_layer_info_to_db,
     update_layer_sync_status,
 )
-from computing.STAC_specs import generate_STAC_layerwise
-
-
 @app.task(bind=True)
 def generate_aquifer_vector(self, state, district, block, gee_account_id):
     """
@@ -306,14 +303,6 @@ def generate_aquifer_vector(self, state, district, block, gee_account_id):
         if res["status_code"] == 201 and layer_id:
             update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
             print("sync to geoserver flag is updated")
-
-            layer_STAC_generated = generate_STAC_layerwise.generate_vector_stac(
-                state=state, district=district, block=block, layer_name="aquifer_vector"
-            )
-            update_layer_sync_status(
-                layer_id=layer_id, is_stac_specs_generated=layer_STAC_generated
-            )
-
             layer_at_geoserver = True
 
     return layer_at_geoserver

--- a/computing/misc/drainage_lines.py
+++ b/computing/misc/drainage_lines.py
@@ -22,7 +22,6 @@ from utilities.constants import (
     PAN_INDIA_DRAINAGE_LINES_DATASET,
 )
 from nrm_app.celery import app
-from computing.STAC_specs import generate_STAC_layerwise
 
 
 @app.task(bind=True)
@@ -104,20 +103,7 @@ def clip_drainage_lines(
             if res["status_code"] == 201 and layer_id:
                 update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
                 print("sync to geoserver flag is updated")
-
-                layer_STAC_generated = False
-                if state and district and block:
-                    layer_STAC_generated = generate_STAC_layerwise.generate_vector_stac(
-                        state=state,
-                        district=district,
-                        block=block,
-                        layer_name="drainage_lines_vector",
-                    )
-                    update_layer_sync_status(
-                        layer_id=layer_id, is_stac_specs_generated=layer_STAC_generated
-                    )
-
-                    layer_at_geoserver = True
+                layer_at_geoserver = True
 
         except Exception as e:
             print("Exception in syncing Drainage line to geoserver", e)

--- a/computing/misc/nrega.py
+++ b/computing/misc/nrega.py
@@ -27,8 +27,6 @@ import ee
 import numpy as np
 import shutil
 
-from computing.STAC_specs import generate_STAC_layerwise
-
 
 def export_shp_to_gee(district, block, layer_path, asset_id, gee_account_id):
     print("Inside export shp to gee")
@@ -178,20 +176,7 @@ def clip_nrega_district_block(self, state, district, block, gee_account_id):
         res = push_shape_to_geoserver(output_dir, workspace="nrega_assets")
 
         if res["status_code"] == 201 and layer_id:
-
             update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
-
-            layer_STAC_generated = generate_STAC_layerwise.generate_vector_stac(
-                state=state,
-                district=district,
-                block=block,
-                layer_name="nrega_vector",
-            )
-
-            update_layer_sync_status(
-                layer_id=layer_id,
-                is_stac_specs_generated=layer_STAC_generated,
-            )
 
             layer_at_geoserver = True
             print("nrega data sync to geoserver")

--- a/computing/misc/restoration_opportunity.py
+++ b/computing/misc/restoration_opportunity.py
@@ -18,7 +18,6 @@ from computing.utils import (
     update_layer_sync_status,
 )
 from utilities.constants import WRI_LAND_RESTORATION_DATASET
-from computing.STAC_specs import generate_STAC_layerwise
 
 
 @app.task(bind=True)
@@ -94,18 +93,6 @@ def clip_raster(roi, state, district, block, description):
         if res and layer_id:
             update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
             print("sync to geoserver flag is updated")
-
-            layer_STAC_generated = False
-            layer_STAC_generated = generate_STAC_layerwise.generate_raster_stac(
-                state=state,
-                district=district,
-                block=block,
-                layer_name="wri_restoration_raster",
-            )
-
-            update_layer_sync_status(
-                layer_id=layer_id, is_stac_specs_generated=layer_STAC_generated
-            )
 
         return asset_id
     return None

--- a/computing/misc/soge_vector.py
+++ b/computing/misc/soge_vector.py
@@ -18,7 +18,6 @@ from computing.utils import (
 )
 from computing.utils import sync_fc_to_geoserver
 from utilities.constants import SOGE_DATASET
-from computing.STAC_specs import generate_STAC_layerwise
 
 
 @app.task(bind=True)
@@ -150,16 +149,5 @@ def generate_soge_vector(self, state, district, block, gee_account_id):
         if res["status_code"] == 201 and layer_id:
             update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
             print("sync to geoserver flag is updated")
-
-            layer_STAC_generated = False
-            layer_STAC_generated = generate_STAC_layerwise.generate_vector_stac(
-                state=state,
-                district=district,
-                block=block,
-                layer_name="stage_of_groundwater_extraction_vector",
-            )
-            update_layer_sync_status(
-                layer_id=layer_id, is_stac_specs_generated=layer_STAC_generated
-            )
             layer_at_geoserver = True
     return layer_at_geoserver

--- a/computing/models.py
+++ b/computing/models.py
@@ -69,3 +69,37 @@ class Layer(models.Model):
 
     def __str__(self):
         return str(self.layer_name)
+
+
+class LayerMapping(models.Model):
+    """Registry mirroring `data/STAC_specs/input/metadata/layer_mapping.csv`.
+
+    Resolves a saved `Layer` (dataset + geoserver-style layer_name) to the
+    canonical STAC `layer_name` and `layer_type` so STAC generation can be
+    triggered automatically without hardcoding per-task strings.
+    """
+
+    id = models.AutoField(primary_key=True)
+    display_name = models.CharField(max_length=255, blank=True, default="")
+    layer_type = models.CharField(max_length=16, choices=LayerType.choices)
+    layer_name = models.CharField(max_length=255, db_index=True)
+    spatial_resolution_in_meters = models.FloatField(null=True, blank=True)
+    ee_layer_name = models.CharField(max_length=255, blank=True, default="")
+    db_dataset_name = models.CharField(max_length=255, db_index=True)
+    geoserver_workspace_name = models.CharField(max_length=255, blank=True, default="")
+    geoserver_layer_name = models.CharField(max_length=511, blank=True, default="")
+    start_year = models.CharField(max_length=16, blank=True, default="")
+    end_year = models.CharField(max_length=16, blank=True, default="")
+    style_file_url = models.CharField(max_length=1024, blank=True, default="")
+    theme = models.CharField(max_length=255, blank=True, default="")
+    auto_stac = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "Layer Mapping"
+        verbose_name_plural = "Layer Mappings"
+        unique_together = (("layer_name", "layer_type", "ee_layer_name"),)
+
+    def __str__(self):
+        return f"{self.layer_name} ({self.layer_type})"

--- a/computing/mws/generate_hydrology.py
+++ b/computing/mws/generate_hydrology.py
@@ -22,7 +22,6 @@ from computing.utils import (
     sync_layer_to_geoserver,
     update_layer_sync_status,
 )
-from computing.STAC_specs import generate_STAC_layerwise
 
 
 @app.task(bind=True)
@@ -225,22 +224,5 @@ def generate_hydrology(
         if res["status_code"] == 201 and layer_id:
             update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
             print("sync to geoserver flag is updated")
-
-            if is_annual:
-                layer_STAC_generated = False
-                layer_STAC_generated = generate_STAC_layerwise.generate_vector_stac(
-                    state=state,
-                    district=district,
-                    block=block,
-                    layer_name="change_in_well_depth_vector",
-                )
-                update_layer_sync_status(
-                    layer_id=layer_id, is_stac_specs_generated=layer_STAC_generated
-                )
-            else:
-                update_layer_sync_status(
-                    layer_id=layer_id, is_stac_specs_generated=False
-                )
-
             layer_at_geoserver = True
     return layer_at_geoserver

--- a/computing/signals.py
+++ b/computing/signals.py
@@ -1,0 +1,135 @@
+"""Auto-trigger STAC collection generation when a Layer is synced to GeoServer.
+
+The handler resolves the saved `Layer` (which stores a *templated* GeoServer
+layer name) back to the canonical STAC `layer_name` / `layer_type` via the
+`LayerMapping` registry (sourced from `layer_mapping.csv`), then dispatches the
+`generate_stac_collection_task` Celery task asynchronously.
+
+This removes the need for every layer-generation task to hardcode the STAC
+parameters and to call STAC generation synchronously.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from computing.models import Layer, LayerMapping
+from utilities.gee_utils import valid_gee_text
+
+log = logging.getLogger(__name__)
+
+
+_STAC_QUEUE = "nrm"
+
+
+def _format_geoserver_name(template: str, layer: Layer) -> str:
+    if not template:
+        return ""
+    misc = layer.misc or {}
+    try:
+        return template.format(
+            district=valid_gee_text(layer.district.district_name.lower()),
+            block=valid_gee_text(layer.block.tehsil_name.lower()),
+            state=valid_gee_text(layer.state.state_name.lower()),
+            start_year=str(misc.get("start_year", "") or ""),
+            end_year=str(misc.get("end_year", "") or ""),
+        )
+    except (KeyError, IndexError, AttributeError):
+        return ""
+
+
+def _resolve_mapping(layer: Layer) -> LayerMapping | None:
+    """Return the best matching LayerMapping for a saved Layer.
+
+    Resolution is keyed on `dataset.name -> LayerMapping.db_dataset_name`.
+    For datasets that fan out into multiple STAC layers (e.g. Change Detection
+    has 5 sub-layers per dataset row), we disambiguate by formatting each
+    candidate's `geoserver_layer_name` template against the Layer's location
+    and year metadata and matching the result against `layer.layer_name`.
+    """
+    if not layer.dataset_id:
+        return None
+
+    dataset_name = (layer.dataset.name or "").strip()
+    if not dataset_name:
+        return None
+
+    candidates = list(
+        LayerMapping.objects.filter(db_dataset_name=dataset_name, auto_stac=True)
+    )
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+
+    layer_name = (layer.layer_name or "").strip()
+    if not layer_name:
+        return None
+
+    matches = [
+        c
+        for c in candidates
+        if _format_geoserver_name(c.geoserver_layer_name, layer) == layer_name
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        log.warning(
+            "STAC auto-trigger: no LayerMapping match for layer id=%s dataset=%s name=%s",
+            layer.id,
+            dataset_name,
+            layer_name,
+        )
+        return None
+
+    log.info(
+        "STAC auto-trigger: %d ambiguous LayerMapping matches for layer id=%s; picking first",
+        len(matches),
+        layer.id,
+    )
+    return matches[0]
+
+
+@receiver(post_save, sender=Layer, dispatch_uid="computing.signals.trigger_stac_on_geoserver_sync")
+def trigger_stac_on_geoserver_sync(sender, instance: Layer, created, **kwargs):
+    if not instance.is_sync_to_geoserver or instance.is_stac_specs_generated:
+        return
+
+    mapping = _resolve_mapping(instance)
+    if mapping is None:
+        return
+
+    # Lazy import: avoids importing Celery / stac_collection at app-loading time.
+    from computing.STAC_specs.stac_collection import generate_stac_collection_task
+
+    misc = instance.misc or {}
+    task_kwargs = dict(
+        layer_type=mapping.layer_type,
+        state=instance.state.state_name,
+        district=instance.district.district_name,
+        block=instance.block.tehsil_name,
+        layer_name=mapping.layer_name,
+        start_year=str(misc.get("start_year", "") or ""),
+        end_year=str(misc.get("end_year", "") or ""),
+        upload_to_s3=True,
+        layer_id=instance.id,
+    )
+
+    log.info(
+        "STAC auto-trigger: dispatching task for layer id=%s (%s/%s)",
+        instance.id,
+        mapping.layer_type,
+        mapping.layer_name,
+    )
+
+    try:
+        generate_stac_collection_task.apply_async(kwargs=task_kwargs, queue=_STAC_QUEUE)
+    except Exception as exc:  # noqa: BLE001
+        log.error(
+            "STAC auto-trigger: failed to dispatch task for layer id=%s: %s",
+            instance.id,
+            exc,
+        )

--- a/computing/surface_water_bodies/swb.py
+++ b/computing/surface_water_bodies/swb.py
@@ -19,7 +19,6 @@ from .swb1 import vectorize_water_pixels
 from .swb2 import waterbody_mws_intersection
 from .swb4 import waterbody_wbc_intersection
 
-from computing.STAC_specs import generate_STAC_layerwise
 from .swb3 import waterbody_catchment_streamorder_properties
 
 
@@ -183,18 +182,6 @@ def sync_asset_to_db_and_geoserver(
         if res.get("status_code") == 201 and layer_id:
             update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
             print("sync to geoserver flag updated")
-            # if state and district and block:
-            #     layer_STAC_generated = False
-            #     layer_STAC_generated = generate_STAC_layerwise.generate_vector_stac(
-            #         state=state,
-            #         district=district,
-            #         block=block,
-            #         layer_name="surface_water_bodies_vector",
-            #     )
-            #     update_layer_sync_status(
-            #         layer_id=layer_id, is_stac_specs_generated=layer_STAC_generated
-            #     )
-
             layer_at_geoserver = True
 
     return layer_at_geoserver

--- a/computing/terrain_descriptor/terrain_clusters.py
+++ b/computing/terrain_descriptor/terrain_clusters.py
@@ -14,7 +14,6 @@ from utilities.gee_utils import (
     make_asset_public,
 )
 from nrm_app.celery import app
-from computing.STAC_specs import generate_STAC_layerwise
 from utilities.constants import FABDEM
 
 
@@ -401,13 +400,5 @@ def sync_to_geoserver(state, district, block, asset_id, layer_id):
     if res["status_code"] == 201 and layer_id:
         update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
         print("sync to geoserver flag is updated")
-
-        layer_STAC_generated = False
-        layer_STAC_generated = generate_STAC_layerwise.generate_vector_stac(
-            state=state, district=district, block=block, layer_name="terrain_vector"
-        )
-        update_layer_sync_status(
-            layer_id=layer_id, is_stac_specs_generated=layer_STAC_generated
-        )
         layer_at_geoserver = True
     return layer_at_geoserver

--- a/computing/terrain_descriptor/terrain_raster.py
+++ b/computing/terrain_descriptor/terrain_raster.py
@@ -17,8 +17,6 @@ import ee
 from .terrain_utils import generate_terrain_classified_raster
 from computing.utils import save_layer_info_to_db, update_layer_sync_status
 
-from computing.STAC_specs import generate_STAC_layerwise
-
 
 @app.task(bind=True)
 def terrain_raster(
@@ -112,19 +110,5 @@ def terrain_raster(
         if res and layer_id:
             update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
             print("sync to geoserver flag is updated")
-
-            layer_STAC_generated = False
-            if state and district and block:
-                layer_STAC_generated = generate_STAC_layerwise.generate_raster_stac(
-                    state=state,
-                    district=district,
-                    block=block,
-                    layer_name="terrain_raster",
-                )
-
-                update_layer_sync_status(
-                    layer_id=layer_id, is_stac_specs_generated=layer_STAC_generated
-                )
-
             layer_at_geoserver = True
     return layer_at_geoserver

--- a/computing/terrain_descriptor/terrain_raster_fabdem.py
+++ b/computing/terrain_descriptor/terrain_raster_fabdem.py
@@ -18,7 +18,6 @@ from utilities.gee_utils import (
 )
 from nrm_app.celery import app
 from utilities.constants import GEE_PATHS, PAN_INDIA_RASTER_FABDEM
-from computing.STAC_specs import generate_STAC_layerwise
 
 
 @app.task(bind=True)
@@ -115,17 +114,5 @@ def generate_terrain_raster_clip(
             if state and district and block:
                 update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
                 print("sync to geoserver flag is updated")
-
-                layer_STAC_generated = False
-                layer_STAC_generated = generate_STAC_layerwise.generate_raster_stac(
-                    state=state,
-                    district=district,
-                    block=block,
-                    layer_name="terrain_raster",
-                )
-
-                update_layer_sync_status(
-                    layer_id=layer_id, is_stac_specs_generated=layer_STAC_generated
-                )
         layer_at_geoserver = True
     return layer_at_geoserver

--- a/computing/tree_health/canopy_height.py
+++ b/computing/tree_health/canopy_height.py
@@ -14,7 +14,6 @@ from utilities.gee_utils import (
     get_gee_dir_path,
 )
 from computing.utils import save_layer_info_to_db, update_layer_sync_status
-from computing.STAC_specs import generate_STAC_layerwise
 
 
 # Celery task to generate canopy height raster
@@ -133,17 +132,6 @@ def tree_health_ch_raster(
 
             if res and layer_id:
                 layer_at_geoserver = True
-
-                # layer_STAC_generated = False
-                # layer_STAC_generated = generate_STAC_layerwise.generate_raster_stac(
-                #     state=state,
-                #     district=district,
-                #     block=block,
-                #     layer_name="ch_raster",
-                #     start_year=year,
-                # )
-
-                # Update sync flag in DB
                 update_layer_sync_status(
                     layer_id=layer_id,
                     sync_to_geoserver=layer_at_geoserver,

--- a/computing/tree_health/ccd.py
+++ b/computing/tree_health/ccd.py
@@ -14,7 +14,6 @@ from utilities.gee_utils import (
     get_gee_dir_path,
 )
 from computing.utils import save_layer_info_to_db, update_layer_sync_status
-from computing.STAC_specs import generate_STAC_layerwise
 
 
 # Celery task to generate CCD raster
@@ -134,17 +133,6 @@ def tree_health_ccd_raster(
 
             if res and layer_id:
                 layer_at_geoserver = True
-
-                # layer_STAC_generated = False
-                # layer_STAC_generated = generate_STAC_layerwise.generate_raster_stac(
-                #     state=state,
-                #     district=district,
-                #     block=block,
-                #     layer_name="ccd_raster",
-                #     start_year=year,
-                # )
-
-                # Update sync status in DB
                 update_layer_sync_status(
                     layer_id=layer_id,
                     sync_to_geoserver=layer_at_geoserver,

--- a/computing/tree_health/overall_change.py
+++ b/computing/tree_health/overall_change.py
@@ -14,7 +14,6 @@ from utilities.gee_utils import (
     get_gee_dir_path,
 )
 from computing.utils import save_layer_info_to_db, update_layer_sync_status
-from computing.STAC_specs import generate_STAC_layerwise
 
 
 @app.task(bind=True)
@@ -111,13 +110,6 @@ def tree_health_overall_change_raster(
 
         if res and layer_id:
             layer_at_geoserver = True
-            # layer_STAC_generated = False
-            # layer_STAC_generated = generate_STAC_layerwise.generate_raster_stac(
-            #     state=state,
-            #     district=district,
-            #     block=block,
-            #     layer_name="tree_cover_change_raster",
-            # )
             update_layer_sync_status(
                 layer_id=layer_id,
                 sync_to_geoserver=layer_at_geoserver,

--- a/computing/utils.py
+++ b/computing/utils.py
@@ -1006,26 +1006,27 @@ def update_layer_sync_status(
         return layer_id
 
     try:
-        layer_obj = Layer.objects.filter(id=layer_id)
+        layer_obj = Layer.objects.filter(id=layer_id).first()
+        if layer_obj is None:
+            return None
+
+        update_fields = []
         if sync_to_geoserver is not None:
-            updated_count = layer_obj.update(is_sync_to_geoserver=sync_to_geoserver)
-
-            if updated_count > 0:
-                print(
-                    f"Updated sync status to {sync_to_geoserver} for layer ID: {layer_id}"
-                )
-                return layer_id
-
+            layer_obj.is_sync_to_geoserver = sync_to_geoserver
+            update_fields.append("is_sync_to_geoserver")
         if is_stac_specs_generated is not None:
-            updated_count = layer_obj.update(
-                is_stac_specs_generated=is_stac_specs_generated
-            )
+            layer_obj.is_stac_specs_generated = is_stac_specs_generated
+            update_fields.append("is_stac_specs_generated")
 
-            if updated_count > 0:
-                print(
-                    f"Updated sync status to {is_stac_specs_generated} for layer ID: {layer_id}"
-                )
-                return layer_id
+        # `save(update_fields=...)` fires the post_save signal so the STAC
+        # auto-trigger handler in `computing.signals` can pick up the flip.
+        if update_fields:
+            layer_obj.save(update_fields=update_fields)
+            print(
+                f"Updated {update_fields} for layer ID: {layer_id} "
+                f"(sync={sync_to_geoserver}, stac={is_stac_specs_generated})"
+            )
+            return layer_id
 
     except Exception as e:
         print(f"Error updating layer sync status: {e}")

--- a/dpr/gen_dpr.py
+++ b/dpr/gen_dpr.py
@@ -17,6 +17,7 @@ from shapely.geometry import Point
 
 from dpr.mapping import populate_maintenance_from_waterbody
 from dpr.utils import ensure_str, get_waterbody_repair_activities, transform_name
+from moderation.views import sync_odk_to_csdb
 from nrm_app.settings import (
     DEBUG,
     EMAIL_HOST,
@@ -38,8 +39,8 @@ from .models import (
 )
 from .services import (
     get_crops_data,
-    get_livestock_data,
     get_livelihood_data,
+    get_livestock_data,
     get_maintenance_data,
     get_nrm_works_data,
 )
@@ -51,7 +52,6 @@ from .utils import (
     to_utf8,
     transform_name,
 )
-from moderation.views import sync_odk_to_csdb
 
 logger = setup_logger(__name__)
 
@@ -68,7 +68,7 @@ def create_dpr_document(plan):
 
     doc = initialize_document()  # doc init
 
-    logger.info("Database sync started") # db sync
+    logger.info("Database sync started")  # db sync
     sync_odk_to_csdb()
     logger.info("Database sync complete")
 
@@ -100,39 +100,43 @@ def create_dpr_document(plan):
     )
     add_section_separator(doc)
     logger.info("Section B completed")
-    
+
     add_section_c(doc, plan)
     add_section_separator(doc)
     logger.info("Section C completed")
-    
+
     add_section_d(doc, plan, settlement_mws_ids, mws_gdf)
     add_section_separator(doc)
     logger.info("Section D completed")
-    
+
     add_section_e(doc, plan)
     add_section_separator(doc)
     logger.info("Section E completed")
-    
+
     add_section_f(doc, plan, mws_fortnight)
     add_section_separator(doc)
     logger.info("Section F completed")
-    
+
     add_section_g(doc, plan, mws_fortnight)
     add_section_separator(doc)
     logger.info("Section G completed")
 
     # MARK: local save /var/www/tmp/dpr/
-    # if DEBUG:
-    #     file_path = TMP_LOCATION + "dpr/"
+    if DEBUG:
+        file_path = TMP_LOCATION + "dpr/"
 
-    #     if not os.path.exists(file_path):
-    #         os.makedirs(file_path)
-    #     doc.save(file_path + plan.plan + ".docx")
+        if not os.path.exists(file_path):
+            os.makedirs(file_path)
+        doc.save(file_path + plan.plan + ".docx")
     return doc
 
 
 def get_data_for_settlement(planid):
-    return ODK_settlement.objects.filter(plan_id=planid).exclude(status_re="rejected").exclude(is_deleted=True)
+    return (
+        ODK_settlement.objects.filter(plan_id=planid)
+        .exclude(status_re="rejected")
+        .exclude(is_deleted=True)
+    )
 
 
 def get_settlement_count_for_plan(planid):
@@ -554,7 +558,9 @@ def create_table_livestock(doc, plan):
     for item in get_livestock_data(plan.id):
         row_cells = livestock_table.add_row().cells
         row_cells[0].text = to_utf8(item["settlement_name"])
-        for i, lt in enumerate(["goats", "sheep", "cattle", "piggery", "poultry"], start=1):
+        for i, lt in enumerate(
+            ["goats", "sheep", "cattle", "piggery", "poultry"], start=1
+        ):
             row_cells[i].text = to_utf8(item[lt] or "NA")
 
 
@@ -608,9 +614,11 @@ def create_table_mws(doc, plan, settlement_mws_ids, mws_gdf, unique_mws_ids):
 
 def get_all_wells_with_mws(plan, unique_mws_ids, mws_gdf):
     """Get all wells across all MWS IDs with their corresponding MWS assignment"""
-    wells_in_plan = ODK_well.objects.filter(plan_id=plan.id).exclude(
-        status_re="rejected"
-    ).exclude(is_deleted=True)
+    wells_in_plan = (
+        ODK_well.objects.filter(plan_id=plan.id)
+        .exclude(status_re="rejected")
+        .exclude(is_deleted=True)
+    )
     all_wells_with_mws = []
 
     for well in wells_in_plan:
@@ -635,9 +643,11 @@ def get_all_wells_with_mws(plan, unique_mws_ids, mws_gdf):
 
 def get_all_waterbodies_with_mws(plan, unique_mws_ids, mws_gdf):
     """Get all waterbodies across all MWS IDs with their corresponding MWS assignment"""
-    waterbodies_in_plan = ODK_waterbody.objects.filter(plan_id=plan.id).exclude(
-        status_re="rejected"
-    ).exclude(is_deleted=True)
+    waterbodies_in_plan = (
+        ODK_waterbody.objects.filter(plan_id=plan.id)
+        .exclude(status_re="rejected")
+        .exclude(is_deleted=True)
+    )
     all_waterbodies_with_mws = []
 
     for waterbody in waterbodies_in_plan:
@@ -724,7 +734,9 @@ def populate_consolidated_well_tables(doc, all_wells_with_mws):
         well_usage = "NA"
         if well.data_well and "Well_usage" in well.data_well:
             well_usage_data = well.data_well["Well_usage"]
-            select_one_well_used = ensure_str(well_usage_data.get("select_one_well_used"))
+            select_one_well_used = ensure_str(
+                well_usage_data.get("select_one_well_used")
+            )
             select_one_well_used_other = well_usage_data.get(
                 "select_one_well_used_other"
             )
@@ -760,7 +772,9 @@ def populate_consolidated_well_tables(doc, all_wells_with_mws):
             and "Well_condition" in well.data_well
         ):
             well_condition_data = well.data_well["Well_condition"]
-            well_repairs_type = ensure_str(well_condition_data.get("select_one_repairs_well"))
+            well_repairs_type = ensure_str(
+                well_condition_data.get("select_one_repairs_well")
+            )
             well_repairs_type_other = well_condition_data.get(
                 "select_one_repairs_well_other"
             )
@@ -993,8 +1007,6 @@ def maintenance_gw_table(doc, plan):
         row_cells[7].text = str(m["longitude"])
 
 
-
-
 def maintenance_agri_table(doc, plan):
     headers = [
         "Type of demand",
@@ -1139,8 +1151,14 @@ def add_section_g(doc, plan, mws):
     doc.add_heading("Section G: Proposed New Livelihood Works", level=1)
 
     all_livelihood = get_livelihood_data(plan.id)
-    livestock_fisheries = [r for r in all_livelihood if r["livelihood_work"] in ("Livestock", "Fisheries")]
-    plantations_etc = [r for r in all_livelihood if r["livelihood_work"] not in ("Livestock", "Fisheries")]
+    livestock_fisheries = [
+        r for r in all_livelihood if r["livelihood_work"] in ("Livestock", "Fisheries")
+    ]
+    plantations_etc = [
+        r
+        for r in all_livelihood
+        if r["livelihood_work"] not in ("Livestock", "Fisheries")
+    ]
 
     doc.add_heading("G.1 Livestock and Fisheries", level=2)
     lf_headers = [

--- a/plans/views.py
+++ b/plans/views.py
@@ -1,5 +1,6 @@
 # plans/views.py
-from django.db.models import Avg, Case, CharField as CharFieldOutput, Count, F, Max, Min, Q, Value, When
+from django.db.models import Avg, Case, Count, F, Max, Min, Q, Value, When
+from django.db.models import CharField as CharFieldOutput
 from django.db.models.functions import Coalesce, Concat, Length, Substr, Trim
 from django.utils import timezone
 from rest_framework import permissions, status, viewsets
@@ -8,6 +9,16 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework_simplejwt.authentication import JWTAuthentication
 
+from dpr.mapping import classify_demand_type
+from dpr.models import (
+    Agri_maintenance,
+    DPR_Report,
+    GW_maintenance,
+    ODK_agri,
+    ODK_groundwater,
+    SWB_maintenance,
+    SWB_RS_maintenance,
+)
 from geoadmin.models import UserAPIKey
 from organization.models import Organization
 from projects.models import AppType, Project
@@ -18,17 +29,6 @@ from .serializers import (
     PlanAppSerializer,
     PlanCreateSerializer,
     PlanUpdateSerializer,
-)
-
-from dpr.mapping import classify_demand_type
-from dpr.models import (
-    Agri_maintenance,
-    DPR_Report,
-    GW_maintenance,
-    ODK_agri,
-    ODK_groundwater,
-    SWB_RS_maintenance,
-    SWB_maintenance,
 )
 
 STATE_CENTROIDS = {
@@ -85,7 +85,7 @@ STEWARD_FULL_NAME = Trim(
 )
 
 
-# MARK: Demand Type Counting 
+# MARK: Demand Type Counting
 def _count_demand_types(plan_id_strs):
     from dpr.mapping import classify_demand_type
     from dpr.models import (
@@ -95,8 +95,8 @@ def _count_demand_types(plan_id_strs):
         ODK_agrohorticulture,
         ODK_groundwater,
         ODK_livelihood,
-        SWB_RS_maintenance,
         SWB_maintenance,
+        SWB_RS_maintenance,
     )
 
     community = 0
@@ -117,29 +117,43 @@ def _count_demand_types(plan_id_strs):
     # Fetch full JSON dict and extract key in Python to avoid ->operator issues on text columns
     _tally(
         (d or {}).get("demand_type")
-        for d in GW_maintenance.objects.filter(plan_id__in=plan_id_strs).exclude(is_deleted=True).values_list("data_gw_maintenance", flat=True)
+        for d in GW_maintenance.objects.filter(plan_id__in=plan_id_strs)
+        .exclude(is_deleted=True)
+        .values_list("data_gw_maintenance", flat=True)
     )
     _tally(
         (d or {}).get("demand_type")
-        for d in Agri_maintenance.objects.filter(plan_id__in=plan_id_strs).exclude(is_deleted=True).values_list("data_agri_maintenance", flat=True)
+        for d in Agri_maintenance.objects.filter(plan_id__in=plan_id_strs)
+        .exclude(is_deleted=True)
+        .values_list("data_agri_maintenance", flat=True)
     )
     _tally(
         (d or {}).get("demand_type")
-        for d in SWB_maintenance.objects.filter(plan_id__in=plan_id_strs).exclude(is_deleted=True).values_list("data_swb_maintenance", flat=True)
+        for d in SWB_maintenance.objects.filter(plan_id__in=plan_id_strs)
+        .exclude(is_deleted=True)
+        .values_list("data_swb_maintenance", flat=True)
     )
     _tally(
         (d or {}).get("demand_type")
-        for d in SWB_RS_maintenance.objects.filter(plan_id__in=plan_id_strs).exclude(is_deleted=True).values_list("data_swb_rs_maintenance", flat=True)
+        for d in SWB_RS_maintenance.objects.filter(plan_id__in=plan_id_strs)
+        .exclude(is_deleted=True)
+        .values_list("data_swb_rs_maintenance", flat=True)
     )
 
     # Section F — NRM works models
     _tally(
         (d or {}).get("demand_type")
-        for d in ODK_groundwater.objects.filter(plan_id__in=plan_id_strs).exclude(is_deleted=True).exclude(status_re="rejected").values_list("data_groundwater", flat=True)
+        for d in ODK_groundwater.objects.filter(plan_id__in=plan_id_strs)
+        .exclude(is_deleted=True)
+        .exclude(status_re="rejected")
+        .values_list("data_groundwater", flat=True)
     )
     _tally(
         (d or {}).get("demand_type_irrigation")
-        for d in ODK_agri.objects.filter(plan_id__in=plan_id_strs).exclude(is_deleted=True).exclude(status_re="rejected").values_list("data_agri", flat=True)
+        for d in ODK_agri.objects.filter(plan_id__in=plan_id_strs)
+        .exclude(is_deleted=True)
+        .exclude(status_re="rejected")
+        .values_list("data_agri", flat=True)
     )
 
     # Section G — Livelihood works (G.1 Livestock/Fisheries, G.2 Plantations/Kitchen Gardens)
@@ -158,19 +172,22 @@ def _count_demand_types(plan_id_strs):
 
             if (
                 str(livestock.get("is_demand_livestock", "")).lower() == "yes"
-                or str(dl.get("select_one_demand_promoting_livestock", "")).lower() == "yes"
+                or str(dl.get("select_one_demand_promoting_livestock", "")).lower()
+                == "yes"
             ):
                 yield livestock.get("livestock_demand")
 
             if (
                 str(fisheries.get("is_demand_fisheris", "")).lower() == "yes"
-                or str(dl.get("select_one_demand_promoting_fisheries", "")).lower() == "yes"
+                or str(dl.get("select_one_demand_promoting_fisheries", "")).lower()
+                == "yes"
             ):
                 yield fisheries.get("demand_type_fisheries")
 
             if (
                 str(dl.get("select_one_demand_plantation", "")).lower() == "yes"
-                or str(plantations.get("select_plantation_demands", "")).lower() == "yes"
+                or str(plantations.get("select_plantation_demands", "")).lower()
+                == "yes"
             ):
                 yield plantations.get("demand_type_plantations")
 
@@ -190,23 +207,24 @@ def _count_demand_types(plan_id_strs):
         .values_list("data_agohorticulture", flat=True)
     )
 
-    return {"community_demands": community, "individual_demands": individual, "total_demands": total}
+    return {
+        "community_demands": community,
+        "individual_demands": individual,
+        "total_demands": total,
+    }
 
 
 def _build_steward_meta_stats(queryset, organization_id=None):
-    valid_steward_qs = (
-        User.objects.filter(groups__name="App User")
-        .exclude(organization_id=CFPT_ORG_ID)
+    valid_steward_qs = User.objects.filter(groups__name="App User").exclude(
+        organization_id=CFPT_ORG_ID
     )
     if organization_id:
         valid_steward_qs = valid_steward_qs.filter(organization_id=organization_id)
     total_stewards = valid_steward_qs.count()
 
-    valid_steward_names = (
-        valid_steward_qs
-        .annotate(full_name=STEWARD_FULL_NAME)
-        .values_list("full_name", flat=True)
-    )
+    valid_steward_names = valid_steward_qs.annotate(
+        full_name=STEWARD_FULL_NAME
+    ).values_list("full_name", flat=True)
     queryset = queryset.filter(facilitator_name__in=valid_steward_names)
 
     effective_village = Case(
@@ -223,15 +241,12 @@ def _build_steward_meta_stats(queryset, organization_id=None):
     )
     qs = queryset.annotate(effective_village=effective_village)
 
-    per_steward = (
-        qs.values("facilitator_name")
-        .annotate(
-            plan_count=Count("id"),
-            completed_count=Count("id", filter=Q(is_completed=True)),
-            in_progress_count=Count("id", filter=Q(is_completed=False)),
-            dpr_generated=Count("id", filter=Q(is_dpr_generated=True)),
-            dpr_reviewed=Count("id", filter=Q(is_dpr_reviewed=True)),
-        )
+    per_steward = qs.values("facilitator_name").annotate(
+        plan_count=Count("id"),
+        completed_count=Count("id", filter=Q(is_completed=True)),
+        in_progress_count=Count("id", filter=Q(is_completed=False)),
+        dpr_generated=Count("id", filter=Q(is_dpr_generated=True)),
+        dpr_reviewed=Count("id", filter=Q(is_dpr_reviewed=True)),
     )
 
     agg = per_steward.aggregate(
@@ -240,7 +255,10 @@ def _build_steward_meta_stats(queryset, organization_id=None):
         max_plans=Max("plan_count"),
         avg_completion=Avg(
             Case(
-                When(plan_count__gt=0, then=F("completed_count") * 100.0 / F("plan_count")),
+                When(
+                    plan_count__gt=0,
+                    then=F("completed_count") * 100.0 / F("plan_count"),
+                ),
                 default=Value(0.0),
             )
         ),
@@ -267,8 +285,7 @@ def _build_steward_meta_stats(queryset, organization_id=None):
             "steward_count": s["steward_count"],
         }
         for s in (
-            valid_steward_qs
-            .filter(organization__isnull=False)
+            valid_steward_qs.filter(organization__isnull=False)
             .values("organization", "organization__name")
             .annotate(steward_count=Count("id"))
             .order_by("-steward_count")
@@ -298,7 +315,9 @@ def _build_steward_meta_stats(queryset, organization_id=None):
         }
         for s in (
             qs.filter(district_soi__isnull=False)
-            .values("district_soi", "district_soi__district_name", "state_soi__state_name")
+            .values(
+                "district_soi", "district_soi__district_name", "state_soi__state_name"
+            )
             .annotate(steward_count=Count("facilitator_name", distinct=True))
             .order_by("-steward_count")
         )
@@ -363,17 +382,14 @@ def _build_steward_meta_stats(queryset, organization_id=None):
 
 
 def _build_steward_listing(queryset):
-    valid_steward_qs = (
-        User.objects.filter(groups__name="App User")
-        .exclude(organization_id=CFPT_ORG_ID)
+    valid_steward_qs = User.objects.filter(groups__name="App User").exclude(
+        organization_id=CFPT_ORG_ID
     )
     total_stewards = valid_steward_qs.count()
 
-    valid_steward_names = (
-        valid_steward_qs
-        .annotate(full_name=STEWARD_FULL_NAME)
-        .values_list("full_name", flat=True)
-    )
+    valid_steward_names = valid_steward_qs.annotate(
+        full_name=STEWARD_FULL_NAME
+    ).values_list("full_name", flat=True)
     queryset = queryset.filter(facilitator_name__in=valid_steward_names)
 
     effective_village = Case(
@@ -408,9 +424,17 @@ def _build_steward_listing(queryset):
     states_by_steward = {}
     all_states = {}
     for row in qs.filter(facilitator_name__in=steward_names).values(
-        "facilitator_name", "id", "plan", "is_completed", "effective_village",
-        "organization", "organization__name", "project", "project__name",
-        "state_soi", "state_soi__state_name",
+        "facilitator_name",
+        "id",
+        "plan",
+        "is_completed",
+        "effective_village",
+        "organization",
+        "organization__name",
+        "project",
+        "project__name",
+        "state_soi",
+        "state_soi__state_name",
     ):
         name = row["facilitator_name"]
         plans_by_steward.setdefault(name, []).append(
@@ -423,11 +447,17 @@ def _build_steward_listing(queryset):
         )
         villages_by_steward.setdefault(name, set()).add(row["effective_village"])
         if row["organization"]:
-            orgs_by_steward.setdefault(name, {})[row["organization"]] = row["organization__name"]
+            orgs_by_steward.setdefault(name, {})[row["organization"]] = row[
+                "organization__name"
+            ]
         if row["project"]:
-            projects_by_steward.setdefault(name, {})[row["project"]] = row["project__name"]
+            projects_by_steward.setdefault(name, {})[row["project"]] = row[
+                "project__name"
+            ]
         if row["state_soi"]:
-            states_by_steward.setdefault(name, {})[row["state_soi"]] = row["state_soi__state_name"]
+            states_by_steward.setdefault(name, {})[row["state_soi"]] = row[
+                "state_soi__state_name"
+            ]
             all_states[row["state_soi"]] = row["state_soi__state_name"]
 
     stewards = [
@@ -436,7 +466,10 @@ def _build_steward_listing(queryset):
             "plan_count": s["plan_count"],
             "completed_count": s["completed_count"],
             "organization": next(
-                ({"id": k, "name": v} for k, v in orgs_by_steward.get(s["facilitator_name"], {}).items()),
+                (
+                    {"id": k, "name": v}
+                    for k, v in orgs_by_steward.get(s["facilitator_name"], {}).items()
+                ),
                 None,
             ),
             "projects": [
@@ -453,7 +486,9 @@ def _build_steward_listing(queryset):
         for s in per_steward
     ]
 
-    working_states = [{"id": k, "name": v} for k, v in sorted(all_states.items(), key=lambda x: x[1])]
+    working_states = [
+        {"id": k, "name": v} for k, v in sorted(all_states.items(), key=lambda x: x[1])
+    ]
 
     return {
         "total_stewards": total_stewards,
@@ -624,20 +659,16 @@ class GlobalPlanViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [GlobalPlanPermission]
 
     def get_queryset(self):
-    # FIX 1: add select_related to prevent N+1 queries
-        queryset = (
-            PlanApp.objects
-            .filter(enabled=True)
-            .select_related(
-                "project",
-                "organization",
-                "created_by",
-            )
+        # FIX 1: add select_related to prevent N+1 queries
+        queryset = PlanApp.objects.filter(enabled=True).select_related(
+            "project",
+            "organization",
+            "created_by",
         )
 
-        tehsil_id   = self.request.query_params.get("tehsil",   None)
+        tehsil_id = self.request.query_params.get("tehsil", None)
         district_id = self.request.query_params.get("district", None)
-        state_id    = self.request.query_params.get("state",    None)
+        state_id = self.request.query_params.get("state", None)
 
         if tehsil_id:
             queryset = queryset.filter(tehsil_soi_id=tehsil_id)
@@ -648,13 +679,16 @@ class GlobalPlanViewSet(viewsets.ReadOnlyModelViewSet):
 
         # FIX 2: icontains is slow — only run when rows are already filtered
         # by state/district/tehsil so it scans fewer rows
-        filter_test_demo = self.request.query_params.get("filter_test_plan", "").lower() == "true"
+        filter_test_demo = (
+            self.request.query_params.get("filter_test_plan", "").lower() == "true"
+        )
         if filter_test_demo:
             queryset = queryset.exclude(
                 Q(plan__icontains="test") | Q(plan__icontains="demo")
             )
 
         return queryset.order_by("-created_at")
+
     @action(detail=False, methods=["get"], url_path="meta-stats")
     def meta_stats(self, request, *args, **kwargs):
         """
@@ -728,19 +762,16 @@ class GlobalPlanViewSet(viewsets.ReadOnlyModelViewSet):
 
         demand_type_counts = _count_demand_types(plan_id_strs)
 
-        valid_steward_qs = (
-            User.objects.filter(groups__name="App User")
-            .exclude(organization__name__iexact="CFPT")
+        valid_steward_qs = User.objects.filter(groups__name="App User").exclude(
+            organization__name__iexact="CFPT"
         )
         if organization_id:
             valid_steward_qs = valid_steward_qs.filter(organization_id=organization_id)
         total_stewards = valid_steward_qs.count()
 
-        valid_steward_names = (
-            valid_steward_qs
-            .annotate(full_name=STEWARD_FULL_NAME)
-            .values_list("full_name", flat=True)
-        )
+        valid_steward_names = valid_steward_qs.annotate(
+            full_name=STEWARD_FULL_NAME
+        ).values_list("full_name", flat=True)
 
         steward_queryset = base_queryset.exclude(
             Q(facilitator_name__isnull=True)
@@ -749,12 +780,13 @@ class GlobalPlanViewSet(viewsets.ReadOnlyModelViewSet):
             | Q(facilitator_name__icontains="demo")
         ).filter(facilitator_name__in=valid_steward_names)
 
-        active_facilitator_names = steward_queryset.values_list("facilitator_name", flat=True).distinct()
+        active_facilitator_names = steward_queryset.values_list(
+            "facilitator_name", flat=True
+        ).distinct()
         gender_counts = {
             row["gender"]: row["count"]
             for row in (
-                valid_steward_qs
-                .annotate(full_name=STEWARD_FULL_NAME)
+                valid_steward_qs.annotate(full_name=STEWARD_FULL_NAME)
                 .filter(full_name__in=active_facilitator_names)
                 .values("gender")
                 .annotate(count=Count("id"))
@@ -769,8 +801,7 @@ class GlobalPlanViewSet(viewsets.ReadOnlyModelViewSet):
         steward_by_org = []
         if not organization_id:
             for stat in (
-                valid_steward_qs
-                .filter(organization__isnull=False)
+                valid_steward_qs.filter(organization__isnull=False)
                 .values("organization", "organization__name")
                 .annotate(steward_count=Count("id"))
                 .order_by("-steward_count")
@@ -955,7 +986,9 @@ class GlobalPlanViewSet(viewsets.ReadOnlyModelViewSet):
             base_queryset = base_queryset.filter(state_soi_id=state_id)
 
         steward_qs = base_queryset.exclude(TEST_FACILITATOR_EXCLUSIONS)
-        response_data = _build_steward_meta_stats(steward_qs, organization_id=organization_id)
+        response_data = _build_steward_meta_stats(
+            steward_qs, organization_id=organization_id
+        )
         response_data["filters_applied"] = {
             "organization_id": organization_id,
             "project_id": project_id,
@@ -992,7 +1025,11 @@ class GlobalPlanViewSet(viewsets.ReadOnlyModelViewSet):
         response_data = _build_steward_listing(steward_qs)
 
         if organization_id:
-            org = Organization.objects.filter(pk=organization_id).values("id", "name").first()
+            org = (
+                Organization.objects.filter(pk=organization_id)
+                .values("id", "name")
+                .first()
+            )
             response_data["organization"] = org
 
         response_data["filters_applied"] = {
@@ -1036,7 +1073,9 @@ class OrganizationPlanViewSet(viewsets.ReadOnlyModelViewSet):
         else:
             return PlanApp.objects.none()
 
-        filter_test_demo = self.request.query_params.get("filter_test_plan", "").lower() == "true"
+        filter_test_demo = (
+            self.request.query_params.get("filter_test_plan", "").lower() == "true"
+        )
         if filter_test_demo:
             queryset = queryset.exclude(
                 Q(plan__icontains="test") | Q(plan__icontains="demo")
@@ -1232,7 +1271,9 @@ class PlanViewSet(viewsets.ModelViewSet):
         if tehsil_id:
             base_queryset = base_queryset.filter(tehsil_soi_id=tehsil_id)
 
-        filter_test_demo = self.request.query_params.get("filter_test_plan", "").lower() == "true"
+        filter_test_demo = (
+            self.request.query_params.get("filter_test_plan", "").lower() == "true"
+        )
         if filter_test_demo:
             base_queryset = base_queryset.exclude(
                 Q(plan__icontains="test") | Q(plan__icontains="demo")
@@ -1450,11 +1491,17 @@ class PlanViewSet(viewsets.ModelViewSet):
 
                     if not (user.is_superadmin or user.is_superuser):
                         if user.groups.filter(
-                            name__in=["Organization Admin", "Org Admin", "Administrator"]
+                            name__in=[
+                                "Organization Admin",
+                                "Org Admin",
+                                "Administrator",
+                            ]
                         ).exists():
                             if project.organization != user.organization:
                                 return Response(
-                                    {"message": "You do not have access to this project."},
+                                    {
+                                        "message": "You do not have access to this project."
+                                    },
                                     status=status.HTTP_403_FORBIDDEN,
                                 )
                         else:
@@ -1463,7 +1510,9 @@ class PlanViewSet(viewsets.ModelViewSet):
                             ).exists()
                             if not user_project_exists:
                                 return Response(
-                                    {"message": "You do not have access to this project."},
+                                    {
+                                        "message": "You do not have access to this project."
+                                    },
                                     status=status.HTTP_403_FORBIDDEN,
                                 )
 
@@ -1478,12 +1527,16 @@ class PlanViewSet(viewsets.ModelViewSet):
                     if user.groups.filter(
                         name__in=["Organization Admin", "Org Admin", "Administrator"]
                     ).exists():
-                        base_queryset = base_queryset.filter(organization=user.organization)
+                        base_queryset = base_queryset.filter(
+                            organization=user.organization
+                        )
                     else:
                         user_projects = UserProjectGroup.objects.filter(
                             user=user
                         ).values_list("project_id", flat=True)
-                        base_queryset = base_queryset.filter(project_id__in=user_projects)
+                        base_queryset = base_queryset.filter(
+                            project_id__in=user_projects
+                        )
 
         state_id = request.query_params.get("state")
         district_id = request.query_params.get("district")
@@ -1522,9 +1575,8 @@ class PlanViewSet(viewsets.ModelViewSet):
             cc_operational_queryset.values("state_soi").distinct().count()
         )
 
-        valid_steward_qs = (
-            User.objects.filter(groups__name="App User")
-            .exclude(organization__name__iexact="CFPT")
+        valid_steward_qs = User.objects.filter(groups__name="App User").exclude(
+            organization__name__iexact="CFPT"
         )
         total_stewards = valid_steward_qs.count()
 
@@ -1535,8 +1587,7 @@ class PlanViewSet(viewsets.ModelViewSet):
                 "steward_count": stat["steward_count"],
             }
             for stat in (
-                valid_steward_qs
-                .filter(organization__isnull=False)
+                valid_steward_qs.filter(organization__isnull=False)
                 .values("organization", "organization__name")
                 .annotate(steward_count=Count("id"))
                 .order_by("-steward_count")
@@ -1690,11 +1741,17 @@ class PlanViewSet(viewsets.ModelViewSet):
 
                     if not (user.is_superadmin or user.is_superuser):
                         if user.groups.filter(
-                            name__in=["Organization Admin", "Org Admin", "Administrator"]
+                            name__in=[
+                                "Organization Admin",
+                                "Org Admin",
+                                "Administrator",
+                            ]
                         ).exists():
                             if project.organization != user.organization:
                                 return Response(
-                                    {"message": "You do not have access to this project."},
+                                    {
+                                        "message": "You do not have access to this project."
+                                    },
                                     status=status.HTTP_403_FORBIDDEN,
                                 )
                         else:
@@ -1703,7 +1760,9 @@ class PlanViewSet(viewsets.ModelViewSet):
                             ).exists()
                             if not user_project_exists:
                                 return Response(
-                                    {"message": "You do not have access to this project."},
+                                    {
+                                        "message": "You do not have access to this project."
+                                    },
                                     status=status.HTTP_403_FORBIDDEN,
                                 )
 
@@ -1718,12 +1777,16 @@ class PlanViewSet(viewsets.ModelViewSet):
                     if user.groups.filter(
                         name__in=["Organization Admin", "Org Admin", "Administrator"]
                     ).exists():
-                        base_queryset = base_queryset.filter(organization=user.organization)
+                        base_queryset = base_queryset.filter(
+                            organization=user.organization
+                        )
                     else:
                         user_projects = UserProjectGroup.objects.filter(
                             user=user
                         ).values_list("project_id", flat=True)
-                        base_queryset = base_queryset.filter(project_id__in=user_projects)
+                        base_queryset = base_queryset.filter(
+                            project_id__in=user_projects
+                        )
 
         state_id = request.query_params.get("state")
         district_id = request.query_params.get("district")
@@ -1745,7 +1808,9 @@ class PlanViewSet(viewsets.ModelViewSet):
             ).exists():
                 effective_org_id = user.organization_id
 
-        response_data = _build_steward_meta_stats(steward_qs, organization_id=effective_org_id)
+        response_data = _build_steward_meta_stats(
+            steward_qs, organization_id=effective_org_id
+        )
         response_data["filters_applied"] = {
             "project_id": project_id,
             "state_id": state_id,
@@ -1784,11 +1849,17 @@ class PlanViewSet(viewsets.ModelViewSet):
 
                     if not (user.is_superadmin or user.is_superuser):
                         if user.groups.filter(
-                            name__in=["Organization Admin", "Org Admin", "Administrator"]
+                            name__in=[
+                                "Organization Admin",
+                                "Org Admin",
+                                "Administrator",
+                            ]
                         ).exists():
                             if project.organization != user.organization:
                                 return Response(
-                                    {"message": "You do not have access to this project."},
+                                    {
+                                        "message": "You do not have access to this project."
+                                    },
                                     status=status.HTTP_403_FORBIDDEN,
                                 )
                         else:
@@ -1797,7 +1868,9 @@ class PlanViewSet(viewsets.ModelViewSet):
                             ).exists()
                             if not user_project_exists:
                                 return Response(
-                                    {"message": "You do not have access to this project."},
+                                    {
+                                        "message": "You do not have access to this project."
+                                    },
                                     status=status.HTTP_403_FORBIDDEN,
                                 )
 
@@ -1812,12 +1885,16 @@ class PlanViewSet(viewsets.ModelViewSet):
                     if user.groups.filter(
                         name__in=["Organization Admin", "Org Admin", "Administrator"]
                     ).exists():
-                        base_queryset = base_queryset.filter(organization=user.organization)
+                        base_queryset = base_queryset.filter(
+                            organization=user.organization
+                        )
                     else:
                         user_projects = UserProjectGroup.objects.filter(
                             user=user
                         ).values_list("project_id", flat=True)
-                        base_queryset = base_queryset.filter(project_id__in=user_projects)
+                        base_queryset = base_queryset.filter(
+                            project_id__in=user_projects
+                        )
 
         state_id = request.query_params.get("state")
         district_id = request.query_params.get("district")


### PR DESCRIPTION
**STAC generates at runtime when layers sync to GeoServer?**

1. Task creates the layer asset (GEE / shapefile / etc.).
2. Task syncs it to GeoServer and gets `status_code == 201`.
3. Task calls `update_layer_sync_status(layer_id, sync_to_geoserver=True)`.
4. That now does `instance.save(update_fields=['is_sync_to_geoserver'])` — which fires `post_save`.
5. `trigger_stac_on_geoserver_sync` resolves the `LayerMapping` (by `dataset.name`, disambiguated by templating `geoserver_layer_name` against `Layer.layer_name` when there are multiple candidates), then dispatches `generate_stac_collection_task.apply_async(..., queue="nrm")` with the canonical STAC `layer_name` + `layer_type` + year metadata.
6. The STAC task runs in the background, writes the collection, uploads to S3 (targeted sync), and on success flips `is_stac_specs_generated=True` via queryset `.update()` (no signal recursion).


---

**Migration** required:
- `python manage.py makemigrations computing`
- `python manage.py migrate computing`
- `python manage.py load_layer_mappings`