### PR TITLE
Antyodaya clipping pipeline

### DIFF
--- a/computing/misc/antyodaya.py
+++ b/computing/misc/antyodaya.py
@@ -22,7 +22,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-import pyogrio
+import geopandas as gpd
 from django.conf import settings
 
 from computing.utils import fix_invalid_geometry_in_gdf, push_shape_to_geoserver
@@ -30,7 +30,7 @@ from nrm_app.celery import app
 from utilities.constants import ANTYODAYA_2020
 
 
-SOURCE_LAYER = "antyodaya_2020"
+SOURCE_LAYER = "cs_antyodaya_2020"
 LOCATION_INDEX = "idx_antyodaya_2020_location"
 OUTPUT_DIR = "data/antyodaya/output/tehsil_data"
 GEOSERVER_WORKSPACE = "antyodaya_2020"
@@ -88,18 +88,14 @@ def _ensure_source_index(source_path: Path) -> None:
 def _location_rows() -> tuple[tuple[str, str, str], ...]:
     source_path = _repo_path(ANTYODAYA_2020)
     _ensure_source_index(source_path)
-    rows = pyogrio.read_dataframe(
-        source_path,
-        sql=(
-            "SELECT DISTINCT state_name, district_name, TEHSIL "
-            f"FROM {SOURCE_LAYER}"
-        ),
-        read_geometry=False,
-    )
-    return tuple(
-        (row.state_name, row.district_name, row.TEHSIL)
-        for row in rows.itertuples(index=False)
-    )
+    with sqlite3.connect(source_path) as connection:
+        rows = connection.execute(
+            f"""
+            SELECT DISTINCT state_name, district_name, TEHSIL
+            FROM {SOURCE_LAYER}
+            """
+        ).fetchall()
+    return tuple((state, district, tehsil) for state, district, tehsil in rows)
 
 
 def _resolve_location(state: str, district: str, block: str) -> tuple[str, str, str]:
@@ -136,7 +132,12 @@ def _read_clip(state_name: str, district_name: str, tehsil_name: str):
         f"district_name = '{_quote_sql(district_name)}' AND "
         f"TEHSIL = '{_quote_sql(tehsil_name)}'"
     )
-    gdf = pyogrio.read_dataframe(source_path, layer=SOURCE_LAYER, where=where)
+    gdf = gpd.read_file(
+        source_path,
+        layer=SOURCE_LAYER,
+        where=where,
+        engine="fiona",
+    )
     if gdf.empty:
         raise ValueError(f"No Antyodaya rows found for {state_name}/{district_name}/{tehsil_name}")
     if gdf.crs is None:
@@ -153,7 +154,7 @@ def _write_clip(gdf, output_dir: Path, layer_name: str) -> Path:
     for path in (gpkg_path, zip_path):
         if path.exists():
             path.unlink()
-    pyogrio.write_dataframe(gdf, gpkg_path, layer=layer_name, driver="GPKG")
+    gdf.to_file(gpkg_path, layer=layer_name, driver="GPKG", engine="fiona")
     return gpkg_path
 
 

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -8,7 +8,7 @@ ADMIN_BOUNDARY_OUTPUT_DIR = "data/admin-boundary/output"
 NREGA_ASSETS_INPUT_DIR = "data/nrega_assets/input"
 NREGA_ASSETS_OUTPUT_DIR = "data/nrega_assets/output"
 
-ANTYODAYA_2020 = "data/antyodaya/output/pan_india_antyodaya_2020.gpkg"
+ANTYODAYA_2020 = "data/antyodaya/output/cs_antyodaya_2020.gpkg"
 LIVESTOCKS = "data/livestock/pan_india_livestock.gpkg"
 
 MERGE_MWS_PATH = "data/merge_mws"


### PR DESCRIPTION
Updating Antyodaya runtime clipping to read the standardized CS asset without any pyogrio under 300 lines. The extra codelines are only there to keep track of any errors at different stages, and help to make it robust, so that we can check for any errors when any issue is reported. 

So, this needs to be used as the script for antyodaya work, without any changes. Please suggest any required changes to me. 