### PR TITLE
Add finalized shared local GPKG pipeline module

### DIFF
--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -334,6 +334,8 @@ DROUGHT_ALGORITHM = "MOD09A1-NDVI/NDWI"
 
 # workspace
 FACILITIES_GEOSERVER_WORKSPACE = "facilities_proximity"
+ANTYODAYA_GEOSERVER_WORKSPACE = "antyodaya_2020"
+LIVESTOCK_GEOSERVER_WORKSPACE = "livestocks"
 
 # other
 FIRST_COMPUTING_API_PATH = "/api/v1/generate_block_layer/"

--- a/utilities/pipelines/README.md
+++ b/utilities/pipelines/README.md
@@ -1,0 +1,30 @@
+# Local Pipeline Core
+
+Shared helpers for fast local geospatial pipelines in `utilities/pipelines`.
+
+The core package keeps reusable mechanics separate from dataset-specific
+pipelines:
+
+- SQLite-backed GeoPackage inspection, filtered reads, and first-run indexes.
+- Standard admin scope resolution from `cs_admin_standard.gpkg`.
+- CSV-to-SQLite sidecars for repeated keyed lookups.
+- Standard request parsing for API and CLI execution.
+- Standard output bundle writers for Unicode-normalized GPKG, README, run
+  metadata (column descriptions, optional rename mappings, and EDA), and one
+  JSON links manifest.
+
+```mermaid
+flowchart TD
+    A[API or CLI request] --> B[StandardRequest]
+    B --> C[CSAdminSource scope lookup]
+    C --> D[Indexed GeoPackage read]
+    D --> E[Dataset-specific pipeline]
+    E --> F[OutputBundle writers]
+    F --> G[Publish and verify GeoServer WFS]
+    G --> H[One local and live links manifest]
+    H --> I[Layer DB registration]
+```
+
+Dataset-specific runtime scripts should import this package from
+`utilities.pipelines` and should not use `pyogrio`. The shared package reads
+GeoPackage rows through SQLite and writes GeoPackages through GeoPandas/Fiona.

--- a/utilities/pipelines/__init__.py
+++ b/utilities/pipelines/__init__.py
@@ -1,0 +1,20 @@
+"""Shared helpers for fast local geospatial pipelines.
+
+The modules in this package are intentionally small and dependency-light. They
+support runtime pipelines that read only the requested administrative scope,
+use SQLite indexes in local GeoPackages, and write standard output bundles for
+API, GeoServer, metadata, and GIS handoff use.
+"""
+
+from .admin import AdminScope, CSAdminSource
+from .publish import register_layer
+from .schema import StandardRequest, api_request_payload, load_config
+
+__all__ = [
+    "AdminScope",
+    "CSAdminSource",
+    "StandardRequest",
+    "api_request_payload",
+    "register_layer",
+    "load_config",
+]

--- a/utilities/pipelines/admin.py
+++ b/utilities/pipelines/admin.py
@@ -1,0 +1,364 @@
+"""Admin-boundary selection helpers for local pipelines."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Sequence
+
+import pandas as pd
+
+try:
+    from utilities.constants import ADMIN_BOUNDARY_GPKG
+except ImportError:
+    ADMIN_BOUNDARY_GPKG = "data/admin-boundary/cs_admin_standard.gpkg"
+
+from .gpkg import (
+    IndexSpec,
+    column_expression,
+    ensure_indexes,
+    lower_key_expression,
+    quote_identifier,
+    read_features,
+    read_table,
+)
+
+
+ADMIN_TABLE = "cs_admin_standard"
+ADMIN_GEOMETRY_COLUMN = "geom"
+ADMIN_DEFAULT_COLUMNS = (
+    "fid",
+    "state_name",
+    "district_name",
+    "TEHSIL",
+    "pc11_state_id",
+    "pc11_district_id",
+    "pc11_subdistrict_id",
+    "pc11_village_id",
+    "village_id",
+    "NAME",
+)
+ADMIN_PRESENTATION_COLUMNS = (
+    "index",
+    "state_id",
+    "district_id",
+    "tehsil_id",
+    "village_id",
+    "state_name",
+    "district_name",
+    "tehsil_name",
+    "village_name",
+)
+#: Shared descriptions for the standard admin columns emitted by every local
+#: pipeline output, used to build column dictionaries and README references.
+ADMIN_COLUMN_DESCRIPTIONS = {
+    "index": "Stable row index of the village in the Core Stack standard admin boundary.",
+    "state_id": "Census 2011 (PC11) state code.",
+    "district_id": "Census 2011 (PC11) district code.",
+    "tehsil_id": "Census 2011 (PC11) sub-district (tehsil/block) code.",
+    "village_id": "Core Stack village identifier used for keyed dataset joins.",
+    "state_name": "State name.",
+    "district_name": "District name.",
+    "tehsil_name": "Tehsil/block name.",
+    "village_name": "Village name.",
+}
+
+INTERNAL_ADMIN_COLUMNS = (
+    "fid",
+    "cs_feature_id",
+    "cs_admin_uid",
+    "core_admin_uid",
+    "pc11_state_id",
+    "pc11_district_id",
+    "pc11_subdistrict_id",
+    "pc11_village_id",
+    "TEHSIL",
+    "NAME",
+)
+
+
+def is_internal_admin_column(column: Any) -> bool:
+    """Return true for fixed source admin fields that should not leak to outputs."""
+
+    return str(column) in INTERNAL_ADMIN_COLUMNS
+
+
+def normalize_key(value: Any) -> str:
+    """Normalize an admin name for consistent lowercase lookup."""
+
+    return " ".join(str(value or "").strip().lower().split())
+
+
+def format_admin_name(value: Any) -> str | None:
+    """Return a readable title-case admin name without changing lookup keys."""
+
+    if value is None or value != value:
+        return None
+    text = re.sub(r"\s+", " ", str(value).strip())
+    if not text:
+        return None
+    text = re.sub(r"\s*-\s*", " - ", text)
+    text = re.sub(r"(?<=\b[A-Za-z])\.(?=[A-Za-z]\b)", ". ", text)
+    text = re.sub(r"(?<=\b[A-Za-z])\.(?=[A-Za-z]\.)", ". ", text)
+    text = re.sub(r"\s+", " ", text)
+
+    words: list[str] = []
+    for word in text.split(" "):
+        if word == "-":
+            words.append(word)
+            continue
+        pieces = word.split(".")
+        if len(pieces) > 1:
+            formatted = ".".join(piece.upper() if len(piece) == 1 else piece.title() for piece in pieces)
+            words.append(formatted)
+            continue
+        words.append(f"{word.upper()}." if len(word) == 1 and word.isalpha() else word.title())
+    return " ".join(words)
+
+
+def admin_presentation_frame(rows: Any, *, include_geometry: bool = False):
+    """Return standard, compact admin columns for user-facing outputs."""
+
+    frame = rows.copy()
+    rename_map = {
+        "fid": "index",
+        "pc11_state_id": "state_id",
+        "pc11_district_id": "district_id",
+        "pc11_subdistrict_id": "tehsil_id",
+        "TEHSIL": "tehsil_name",
+        "NAME": "village_name",
+    }
+    frame = frame.rename(columns={src: dst for src, dst in rename_map.items() if src in frame.columns})
+    for column in ("state_name", "district_name", "tehsil_name", "village_name"):
+        if column in frame.columns:
+            frame[column] = frame[column].map(format_admin_name)
+    columns = [column for column in ADMIN_PRESENTATION_COLUMNS if column in frame.columns]
+    if include_geometry and "geometry" in frame.columns:
+        columns.append("geometry")
+    return frame[columns].copy()
+
+
+def admin_output_frame(
+    rows: Any,
+    *,
+    value_columns: Sequence[str] = (),
+    include_geometry: bool = False,
+):
+    """Return a user-facing frame with standard admin columns and configured values."""
+
+    frame = rows.copy()
+    presentation = admin_presentation_frame(frame, include_geometry=False)
+    ordered = list(presentation.columns)
+    for column in value_columns:
+        if (
+            column in frame.columns
+            and column not in ordered
+            and not is_internal_admin_column(column)
+        ):
+            ordered.append(column)
+    output = frame.rename(
+        columns={
+            "fid": "index",
+            "pc11_state_id": "state_id",
+            "pc11_district_id": "district_id",
+            "pc11_subdistrict_id": "tehsil_id",
+            "TEHSIL": "tehsil_name",
+            "NAME": "village_name",
+        }
+    )
+    for column in ("state_name", "district_name", "tehsil_name", "village_name"):
+        if column in output.columns:
+            output[column] = output[column].map(format_admin_name)
+    if include_geometry and "geometry" in frame.columns:
+        ordered.append("geometry")
+    return output.reindex(columns=ordered)
+
+
+def _repo_path(path: str | Path, base_dir: str | Path | None = None) -> Path:
+    path = Path(path)
+    if path.is_absolute():
+        return path
+    return Path(base_dir or Path.cwd()) / path
+
+
+def _as_tuple(value: Any) -> tuple[Any, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, (list, tuple, set)):
+        return tuple(value)
+    return (value,)
+
+
+@dataclass(frozen=True)
+class AdminScope:
+    """Administrative selection requested by an API or CLI request."""
+
+    level: str
+    state_name: str | None = None
+    district_name: str | None = None
+    tehsil_name: str | None = None
+    village_ids: tuple[Any, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> "AdminScope":
+        """Build a scope from common API/CLI key names."""
+
+        return cls(
+            level=str(data.get("level") or data.get("scope_level") or "tehsil").lower(),
+            state_name=data.get("state_name") or data.get("state"),
+            district_name=data.get("district_name") or data.get("district"),
+            tehsil_name=data.get("tehsil_name") or data.get("block_name") or data.get("block"),
+            village_ids=_as_tuple(data.get("village_ids") or data.get("village_id")),
+        )
+
+
+@dataclass
+class AdminSelection:
+    """Rows and identifiers selected from the standard admin boundary."""
+
+    scope: AdminScope
+    rows: Any
+    created_indexes: list[str]
+    where_sql: str
+    params: tuple[Any, ...]
+
+    @property
+    def village_ids(self) -> list[Any]:
+        if "village_id" not in self.rows.columns:
+            return []
+        return self.rows["village_id"].dropna().drop_duplicates().tolist()
+
+    @property
+    def pc11_village_ids(self) -> list[Any]:
+        if "pc11_village_id" not in self.rows.columns:
+            return []
+        return self.rows["pc11_village_id"].dropna().drop_duplicates().tolist()
+
+    def id_frame(self) -> pd.DataFrame:
+        """Return the standard identifier columns for joins and QA."""
+
+        columns = [col for col in ADMIN_DEFAULT_COLUMNS if col in self.rows.columns]
+        return pd.DataFrame(self.rows[columns]).copy()
+
+
+class CSAdminSource:
+    """Fast selector for `data/admin-boundary/cs_admin_standard.gpkg`."""
+
+    def __init__(
+        self,
+        path: str | Path = ADMIN_BOUNDARY_GPKG,
+        *,
+        table_name: str = ADMIN_TABLE,
+        base_dir: str | Path | None = None,
+    ) -> None:
+        self.path = _repo_path(path, base_dir)
+        self.table_name = table_name
+
+    @property
+    def required_indexes(self) -> tuple[IndexSpec, ...]:
+        """Indexes used by standard local admin lookups."""
+
+        table = self.table_name
+        return (
+            IndexSpec(
+                name=f"idx_{table}_lower_state_district_tehsil",
+                table=table,
+                expressions=(
+                    lower_key_expression("state_name"),
+                    lower_key_expression("district_name"),
+                    lower_key_expression("TEHSIL"),
+                ),
+            ),
+            IndexSpec(
+                name=f"idx_{table}_village_id",
+                table=table,
+                expressions=(column_expression("village_id"),),
+            ),
+            IndexSpec(
+                name=f"idx_{table}_pc11_village_id",
+                table=table,
+                expressions=(column_expression("pc11_village_id"),),
+            ),
+        )
+
+    def ensure_indexes(self) -> list[str]:
+        """Create missing admin lookup indexes once."""
+
+        return ensure_indexes(self.path, self.required_indexes)
+
+    def _where_for_scope(self, scope: AdminScope) -> tuple[str, tuple[Any, ...]]:
+        level = scope.level.lower()
+        clauses: list[str] = []
+        params: list[Any] = []
+
+        if level in {"state", "district", "tehsil", "block"}:
+            if not scope.state_name:
+                raise ValueError("state_name is required for state/district/tehsil scopes")
+            clauses.append(f"{lower_key_expression('state_name')} = ?")
+            params.append(normalize_key(scope.state_name))
+
+        if level in {"district", "tehsil", "block"}:
+            if not scope.district_name:
+                raise ValueError("district_name is required for district/tehsil scopes")
+            clauses.append(f"{lower_key_expression('district_name')} = ?")
+            params.append(normalize_key(scope.district_name))
+
+        if level in {"tehsil", "block"}:
+            if not scope.tehsil_name:
+                raise ValueError("tehsil_name or block_name is required for tehsil scopes")
+            clauses.append(f"{lower_key_expression('TEHSIL')} = ?")
+            params.append(normalize_key(scope.tehsil_name))
+
+        if level == "village":
+            if not scope.village_ids:
+                raise ValueError("village_ids are required for village scope")
+            placeholders = ", ".join(["?"] * len(scope.village_ids))
+            clauses.append(
+                "("
+                f"{quote_identifier('village_id')} IN ({placeholders}) OR "
+                f"{quote_identifier('pc11_village_id')} IN ({placeholders})"
+                ")"
+            )
+            values = list(scope.village_ids)
+            params.extend(values)
+            params.extend(values)
+
+        if not clauses:
+            raise ValueError(f"Unsupported admin scope level: {scope.level}")
+        return " AND ".join(clauses), tuple(params)
+
+    def read_scope(
+        self,
+        scope: AdminScope,
+        *,
+        columns: Sequence[str] | None = None,
+        include_geometry: bool = True,
+    ) -> AdminSelection:
+        """Read only the admin rows required by a scope."""
+
+        created_indexes = self.ensure_indexes()
+        where, params = self._where_for_scope(scope)
+        read_columns = list(columns or ADMIN_DEFAULT_COLUMNS)
+        if include_geometry:
+            if ADMIN_GEOMETRY_COLUMN not in read_columns:
+                read_columns.append(ADMIN_GEOMETRY_COLUMN)
+            rows = read_features(
+                self.path,
+                self.table_name,
+                columns=read_columns,
+                where=where,
+                params=params,
+                geometry_column_name=ADMIN_GEOMETRY_COLUMN,
+            )
+        else:
+            rows = read_table(
+                self.path,
+                self.table_name,
+                columns=read_columns,
+                where=where,
+                params=params,
+            )
+        if rows.empty:
+            raise ValueError(f"No admin rows found for scope: {scope}")
+        return AdminSelection(scope, rows, created_indexes, where, params)

--- a/utilities/pipelines/gpkg.py
+++ b/utilities/pipelines/gpkg.py
@@ -1,0 +1,249 @@
+"""SQLite-backed GeoPackage helpers for local pipeline reads.
+
+GeoPackages are SQLite databases. For the local runtime pipelines, using SQLite
+directly keeps scope resolution and attribute filtering explicit and fast while
+still allowing GeoPandas/Fiona to handle output writing.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import pandas as pd
+
+
+def quote_identifier(name: str) -> str:
+    """Return a SQLite identifier quoted with double quotes."""
+
+    return '"' + str(name).replace('"', '""') + '"'
+
+
+def connect_gpkg(path: str | Path, *, read_only: bool = False) -> sqlite3.Connection:
+    """Open a GeoPackage SQLite connection with practical runtime pragmas."""
+
+    path = Path(path)
+    if read_only:
+        connection = sqlite3.connect(f"file:{path.as_posix()}?mode=ro", uri=True)
+    else:
+        connection = sqlite3.connect(path)
+    connection.execute("PRAGMA temp_store = MEMORY")
+    return connection
+
+
+@dataclass(frozen=True)
+class GPKGLayer:
+    """Minimal metadata for a GeoPackage content table."""
+
+    table_name: str
+    data_type: str
+    identifier: str | None = None
+
+
+@dataclass(frozen=True)
+class IndexSpec:
+    """Description of a SQLite index required by a pipeline."""
+
+    name: str
+    table: str
+    expressions: tuple[str, ...]
+    unique: bool = False
+
+    def create_sql(self) -> str:
+        unique = "UNIQUE " if self.unique else ""
+        expressions = ", ".join(self.expressions)
+        return (
+            f"CREATE {unique}INDEX IF NOT EXISTS {quote_identifier(self.name)} "
+            f"ON {quote_identifier(self.table)} ({expressions})"
+        )
+
+
+def column_expression(column: str) -> str:
+    """Return a quoted column expression for an index or SELECT list."""
+
+    return quote_identifier(column)
+
+
+def lower_key_expression(column: str) -> str:
+    """Return a normalized lowercase string expression usable in an index."""
+
+    return f"lower(trim({quote_identifier(column)}))"
+
+
+def table_exists(connection: sqlite3.Connection, table_name: str) -> bool:
+    """Return whether a table or view exists in a SQLite database."""
+
+    return (
+        connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND name = ?",
+            (table_name,),
+        ).fetchone()
+        is not None
+    )
+
+
+def index_exists(connection: sqlite3.Connection, index_name: str) -> bool:
+    """Return whether an index exists in a SQLite database."""
+
+    return (
+        connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
+            (index_name,),
+        ).fetchone()
+        is not None
+    )
+
+
+def gpkg_layers(connection: sqlite3.Connection) -> list[GPKGLayer]:
+    """Read GeoPackage content entries."""
+
+    if not table_exists(connection, "gpkg_contents"):
+        return []
+    rows = connection.execute(
+        "SELECT table_name, data_type, identifier FROM gpkg_contents ORDER BY table_name"
+    ).fetchall()
+    return [GPKGLayer(str(row[0]), str(row[1]), row[2]) for row in rows]
+
+
+def feature_layers(connection: sqlite3.Connection) -> list[str]:
+    """Return feature layer table names in a GeoPackage."""
+
+    return [layer.table_name for layer in gpkg_layers(connection) if layer.data_type == "features"]
+
+
+def table_columns(connection: sqlite3.Connection, table_name: str) -> list[str]:
+    """Return column names for a table."""
+
+    return [str(row[1]) for row in connection.execute(f"PRAGMA table_info({quote_identifier(table_name)})")]
+
+
+def geometry_column(connection: sqlite3.Connection, table_name: str) -> str | None:
+    """Return the geometry column for a GeoPackage feature table."""
+
+    if not table_exists(connection, "gpkg_geometry_columns"):
+        return None
+    row = connection.execute(
+        "SELECT column_name FROM gpkg_geometry_columns WHERE table_name = ?",
+        (table_name,),
+    ).fetchone()
+    return str(row[0]) if row else None
+
+
+def layer_crs(connection: sqlite3.Connection, table_name: str) -> str | None:
+    """Return an EPSG CRS string for a GeoPackage feature table when known."""
+
+    if not table_exists(connection, "gpkg_geometry_columns"):
+        return None
+    row = connection.execute(
+        "SELECT srs_id FROM gpkg_geometry_columns WHERE table_name = ?",
+        (table_name,),
+    ).fetchone()
+    if not row or row[0] is None:
+        return None
+    try:
+        srs_id = int(row[0])
+    except (TypeError, ValueError):
+        return None
+    return f"EPSG:{srs_id}" if srs_id > 0 else None
+
+
+def ensure_indexes(path: str | Path, specs: Sequence[IndexSpec]) -> list[str]:
+    """Create missing indexes and return the names that were created."""
+
+    created: list[str] = []
+    with connect_gpkg(path) as connection:
+        for spec in specs:
+            if not table_exists(connection, spec.table):
+                raise RuntimeError(f"Cannot create {spec.name}: missing table {spec.table}")
+            if index_exists(connection, spec.name):
+                continue
+            connection.execute(spec.create_sql())
+            created.append(spec.name)
+        connection.commit()
+    return created
+
+
+def gpkg_geometry_to_shape(blob: bytes | memoryview | None):
+    """Decode a GeoPackage geometry blob into a Shapely geometry."""
+
+    if blob is None:
+        return None
+    from shapely import wkb
+
+    data = bytes(blob)
+    if data[:2] != b"GP":
+        return wkb.loads(data)
+    flags = data[3]
+    if flags & 0b00010000:
+        return None
+    envelope_code = (flags >> 1) & 0b00000111
+    envelope_bytes = {0: 0, 1: 32, 2: 48, 3: 48, 4: 64}.get(envelope_code)
+    if envelope_bytes is None:
+        raise ValueError(f"Unsupported GeoPackage geometry envelope code: {envelope_code}")
+    return wkb.loads(data[8 + envelope_bytes :])
+
+
+def placeholders(values: Iterable[Any]) -> str:
+    """Return SQLite placeholders for a non-empty iterable."""
+
+    values = list(values)
+    if not values:
+        raise ValueError("At least one value is required for SQL placeholders")
+    return ", ".join(["?"] * len(values))
+
+
+def read_table(
+    path: str | Path,
+    table_name: str,
+    *,
+    columns: Sequence[str] | None = None,
+    where: str | None = None,
+    params: Sequence[Any] = (),
+) -> pd.DataFrame:
+    """Read an attribute table through SQLite into a pandas DataFrame."""
+
+    select_columns = "*" if columns is None else ", ".join(quote_identifier(col) for col in columns)
+    sql = f"SELECT {select_columns} FROM {quote_identifier(table_name)}"
+    if where:
+        sql += f" WHERE {where}"
+    with connect_gpkg(path, read_only=True) as connection:
+        return pd.read_sql_query(sql, connection, params=tuple(params))
+
+
+def read_features(
+    path: str | Path,
+    table_name: str,
+    *,
+    columns: Sequence[str] | None = None,
+    where: str | None = None,
+    params: Sequence[Any] = (),
+    geometry_column_name: str | None = None,
+) :
+    """Read filtered GeoPackage features without scanning through GDAL.
+
+    The function decodes GeoPackage geometry blobs directly after SQLite has
+    applied the indexed filter.
+    """
+
+    import geopandas as gpd
+
+    with connect_gpkg(path, read_only=True) as connection:
+        geom_col = geometry_column_name or geometry_column(connection, table_name)
+        crs = layer_crs(connection, table_name)
+        if not geom_col:
+            raise RuntimeError(f"{table_name} is not registered as a GeoPackage feature table")
+        read_columns = list(columns or table_columns(connection, table_name))
+        if geom_col not in read_columns:
+            read_columns.append(geom_col)
+        select_columns = ", ".join(quote_identifier(col) for col in read_columns)
+        sql = f"SELECT {select_columns} FROM {quote_identifier(table_name)}"
+        if where:
+            sql += f" WHERE {where}"
+        frame = pd.read_sql_query(sql, connection, params=tuple(params))
+
+    if frame.empty:
+        return gpd.GeoDataFrame(frame.drop(columns=[geom_col], errors="ignore"), geometry=[], crs=crs)
+    geometry = frame.pop(geom_col).map(gpkg_geometry_to_shape)
+    return gpd.GeoDataFrame(frame, geometry=geometry, crs=crs)

--- a/utilities/pipelines/outputs.py
+++ b/utilities/pipelines/outputs.py
@@ -1,0 +1,378 @@
+"""Standard output bundle writers for local geospatial pipelines."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+import pandas as pd
+
+from .unicode import normalize_unicode_data, normalize_unicode_text
+
+
+def slug(value: Any) -> str:
+    """Return a filesystem-safe lowercase slug."""
+
+    import re
+
+    return re.sub(r"[^a-z0-9]+", "_", str(value or "").lower()).strip("_")
+
+
+def utc_now_text() -> str:
+    """Return an ISO UTC timestamp without microseconds."""
+
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def stable_hash(data: Any) -> str:
+    """Return a stable SHA1 hash for JSON-serializable cache metadata."""
+
+    payload = json.dumps(data, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+
+
+def scope_output_identity(prefix: str, scope: Any) -> tuple[tuple[str, ...], str]:
+    """Return output directory parts and a stable layer/result name for a scope."""
+
+    level = str(getattr(scope, "level", "") or "").lower()
+    state = slug(getattr(scope, "state_name", None))
+    district = slug(getattr(scope, "district_name", None))
+    tehsil = slug(getattr(scope, "tehsil_name", None))
+    if level == "state":
+        parts = tuple(part for part in (state,) if part)
+        return parts, "_".join(part for part in (prefix, state) if part)
+    if level == "district":
+        parts = tuple(part for part in (state, district) if part)
+        return parts, "_".join(part for part in (prefix, district) if part)
+    if level == "village":
+        village_ids = tuple(str(value) for value in (getattr(scope, "village_ids", None) or ()))
+        digest = stable_hash({"village_ids": village_ids})[:10] if village_ids else "unknown"
+        return ("village", digest), f"{prefix}_village_{digest}"
+    parts = tuple(part for part in (state, district, tehsil) if part)
+    return parts, "_".join(part for part in (prefix, district, tehsil) if part)
+
+
+def mark_cached_result(result: Mapping[str, Any], started: float) -> dict[str, Any]:
+    """Annotate a cached result with current lookup timing and original timing."""
+
+    cached = dict(result)
+    cached["cache_hit"] = True
+    cached["cached_result_elapsed_seconds"] = cached.get("elapsed_seconds")
+    cached["cache_lookup_seconds"] = round(time.perf_counter() - started, 3)
+    cached["elapsed_seconds"] = cached["cache_lookup_seconds"]
+    return cached
+
+
+def file_signature(path: str | Path) -> dict[str, Any]:
+    """Return a fast file signature and optional tracked SHA1 sidecar value."""
+
+    file_path = Path(path)
+    stat = file_path.stat()
+    sha1_path = Path(f"{file_path.as_posix()}.sha1")
+    sha1 = None
+    if sha1_path.exists():
+        sha1 = sha1_path.read_text().strip().split()[0] or None
+    return {
+        "path": file_path.as_posix(),
+        "size": int(stat.st_size),
+        "mtime_ns": int(stat.st_mtime_ns),
+        "sha1": sha1,
+    }
+
+
+def input_signatures(paths: Mapping[str, str | Path]) -> dict[str, dict[str, Any]]:
+    """Return signatures for named input files that exist."""
+
+    signatures: dict[str, dict[str, Any]] = {}
+    for name, path in paths.items():
+        file_path = Path(path)
+        if file_path.exists():
+            signatures[name] = file_signature(file_path)
+    return signatures
+
+
+def dataframe_eda(frame: pd.DataFrame, *, max_numeric_columns: int = 80) -> dict[str, Any]:
+    """Build a compact EDA summary for a tabular or geospatial output."""
+
+    column_names = [str(column) for column in frame.columns]
+    seen: dict[str, int] = {}
+    summary_names: list[str] = []
+    null_counts: dict[str, int] = {}
+    for position, column in enumerate(frame.columns):
+        name = str(column)
+        seen[name] = seen.get(name, 0) + 1
+        summary_name = name if seen[name] == 1 else f"{name}__{seen[name]}"
+        summary_names.append(summary_name)
+        null_counts[summary_name] = int(frame.iloc[:, position].isna().sum())
+
+    summary: dict[str, Any] = {
+        "row_count": int(len(frame)),
+        "column_count": int(len(frame.columns)),
+        "columns": column_names,
+        "null_counts": null_counts,
+    }
+    if "geometry" in frame.columns:
+        geometry_position = column_names.index("geometry")
+        summary["null_geometry_count"] = int(frame.iloc[:, geometry_position].isna().sum())
+    numeric = frame.select_dtypes(include="number")
+    numeric_summary: dict[str, dict[str, float | int | None]] = {}
+    numeric_seen: dict[str, int] = {}
+    for position, column in enumerate(list(numeric.columns)[:max_numeric_columns]):
+        name = str(column)
+        numeric_seen[name] = numeric_seen.get(name, 0) + 1
+        summary_name = name if numeric_seen[name] == 1 else f"{name}__{numeric_seen[name]}"
+        series = numeric.iloc[:, position].dropna()
+        numeric_summary[summary_name] = {
+            "count": int(series.count()),
+            "min": None if series.empty else float(series.min()),
+            "mean": None if series.empty else float(series.mean()),
+            "max": None if series.empty else float(series.max()),
+        }
+    summary["numeric_summary"] = numeric_summary
+    return summary
+
+
+def friendly_datatype(series: pd.Series) -> str:
+    """Return a human-readable datatype name for column documentation."""
+
+    dtype = series.dtype
+    if str(dtype) == "geometry":
+        return "geometry"
+    if pd.api.types.is_bool_dtype(dtype):
+        return "boolean"
+    if pd.api.types.is_integer_dtype(dtype):
+        return "integer"
+    if pd.api.types.is_float_dtype(dtype):
+        return "number"
+    if pd.api.types.is_datetime64_any_dtype(dtype):
+        return "datetime"
+    return "text"
+
+
+def column_dictionary(
+    frame: pd.DataFrame,
+    describe: Mapping[str, str] | Any = None,
+    rename: Mapping[str, str] | Any = None,
+) -> list[dict[str, Any]]:
+    """Return standard column metadata, including optional rename targets.
+
+    `describe` may be a mapping of column name to description or a callable
+    returning a description (or None) for a column name. `rename` follows the
+    same convention and records only actual source-to-target changes.
+    """
+
+    entries: list[dict[str, Any]] = []
+    for position, column in enumerate(frame.columns):
+        name = str(column)
+        if callable(describe):
+            description = describe(name)
+        elif describe:
+            description = describe.get(name)
+        else:
+            description = None
+        if callable(rename):
+            rename_to = rename(name)
+        elif rename:
+            rename_to = rename.get(name)
+        else:
+            rename_to = None
+        entry = {
+            "column": name,
+            "description": description,
+            "datatype": friendly_datatype(frame.iloc[:, position]),
+        }
+        if rename_to and str(rename_to) != name:
+            entry["rename_to"] = str(rename_to)
+        entries.append(entry)
+    return entries
+
+
+def frame_profile(
+    frame: pd.DataFrame,
+    describe: Mapping[str, str] | Any = None,
+    rename: Mapping[str, str] | Any = None,
+) -> dict[str, Any]:
+    """Return column docs, rename mapping, and EDA for one output layer."""
+
+    columns = column_dictionary(frame, describe, rename)
+    return {
+        "columns": columns,
+        "column_rename_mapping": {
+            entry["column"]: entry["rename_to"]
+            for entry in columns
+            if entry.get("rename_to")
+        },
+        "eda": dataframe_eda(frame),
+    }
+
+
+def _safe_field_value(value: Any) -> Any:
+    if value is None:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    if isinstance(value, (str, int, float)):
+        return normalize_unicode_text(value) if isinstance(value, str) else value
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (dict, list, tuple, set)):
+        return json.dumps(value, default=str)
+    return str(value)
+
+
+def _prepare_gdf_for_file(gdf):
+    """Coerce columns to Fiona-friendly scalar field values."""
+
+    prepared = gdf.copy()
+    geometry_name = prepared.geometry.name
+    if "fid" in prepared.columns and "source_fid" not in prepared.columns:
+        prepared = prepared.rename(columns={"fid": "source_fid"})
+    for column in prepared.columns:
+        if column == geometry_name:
+            continue
+        if str(prepared[column].dtype) == "bool":
+            prepared[column] = prepared[column].astype("int8")
+        elif str(prepared[column].dtype) in {"object", "string"}:
+            prepared[column] = prepared[column].map(_safe_field_value)
+    return prepared
+
+
+@dataclass
+class OutputBundle:
+    """Writer for a standard local pipeline output directory."""
+
+    root: str | Path
+    name: str
+
+    def __post_init__(self) -> None:
+        self.root = Path(self.root)
+
+    @property
+    def path(self) -> Path:
+        return self.root / slug(self.name)
+
+    def ensure(self) -> Path:
+        self.path.mkdir(parents=True, exist_ok=True)
+        return self.path
+
+    def output_path(self, suffix: str) -> Path:
+        self.ensure()
+        return self.path / f"{slug(self.name)}{suffix}"
+
+    def remove_outputs(self, *suffixes: str) -> list[str]:
+        """Remove obsolete artifacts from an earlier contract revision."""
+
+        removed: list[str] = []
+        for suffix in suffixes:
+            path = self.output_path(suffix)
+            if path.exists():
+                path.unlink()
+                removed.append(path.as_posix())
+        return removed
+
+    def write_json(self, data: Mapping[str, Any], suffix: str) -> Path:
+        path = self.output_path(suffix)
+        payload = normalize_unicode_data(data)
+        path.write_text(
+            json.dumps(payload, indent=2, default=str, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def write_metadata(self, data: Mapping[str, Any]) -> Path:
+        payload = {"generated_at_utc": utc_now_text(), **dict(data)}
+        return self.write_json(payload, ".run_metadata.json")
+
+    def write_links(self, data: Mapping[str, Any]) -> Path:
+        """Write the single links manifest for all layers in this run."""
+
+        payload = {"generated_at_utc": utc_now_text(), **dict(data)}
+        return self.write_json(payload, ".links.json")
+
+    def cache_manifest_path(self) -> Path:
+        return self.output_path(".cache_manifest.json")
+
+    def read_cache_manifest(self) -> dict[str, Any] | None:
+        path = self.cache_manifest_path()
+        if not path.exists():
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def write_cache_manifest(self, data: Mapping[str, Any]) -> Path:
+        payload = normalize_unicode_data(
+            {"generated_at_utc": utc_now_text(), **dict(data)}
+        )
+        path = self.cache_manifest_path()
+        path.write_text(
+            json.dumps(payload, indent=2, default=str, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def cached_result(
+        self,
+        *,
+        cache_key: str,
+        signatures: Mapping[str, Any],
+        required_result_paths: tuple[str, ...],
+    ) -> dict[str, Any] | None:
+        """Return a cached result only when request, inputs, and files match."""
+
+        manifest = self.read_cache_manifest()
+        if not manifest:
+            return None
+        if manifest.get("cache_key") != cache_key:
+            return None
+        if manifest.get("input_signatures") != dict(signatures):
+            return None
+        result = dict(manifest.get("result") or {})
+        for key in required_result_paths:
+            path = result.get(key)
+            if not path or not Path(path).exists():
+                return None
+        result["status"] = "cached"
+        result["cache_manifest_path"] = self.cache_manifest_path().as_posix()
+        return result
+
+    def write_readme(self, lines: list[str]) -> Path:
+        self.ensure()
+        path = self.path / "README.md"
+        text = normalize_unicode_text("\n".join(lines).rstrip() + "\n")
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def write_gpkg(
+        self,
+        layers: Mapping[str, Any],
+        suffix: str = ".gpkg",
+    ) -> Path:
+        """Write GeoDataFrame layers to a GeoPackage using Fiona."""
+
+        gpkg_path = self.output_path(suffix)
+        if gpkg_path.exists():
+            gpkg_path.unlink()
+        for layer_name, gdf in layers.items():
+            if gdf is None or len(gdf) == 0:
+                continue
+            gdf = _prepare_gdf_for_file(gdf)
+            # Fiona append mode is brittle with GeoPackage in some local GDAL builds.
+            # Since the output file is unlinked above, writing each named layer in
+            # create/replace mode preserves earlier layers while avoiding append mode.
+            gdf.to_file(
+                gpkg_path,
+                layer=layer_name,
+                driver="GPKG",
+                mode="w",
+                engine="fiona",
+            )
+        if not gpkg_path.exists():
+            raise ValueError("No non-empty layers were provided for GeoPackage output")
+        return gpkg_path

--- a/utilities/pipelines/publish.py
+++ b/utilities/pipelines/publish.py
@@ -1,0 +1,468 @@
+"""GeoServer publishing helpers for local pipeline GeoPackage outputs."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+from xml.sax.saxutils import escape
+
+import requests
+
+
+class GeoServerPublishError(RuntimeError):
+    """Raised when GeoServer publication or verification fails."""
+
+
+@dataclass(frozen=True)
+class GeoServerPublishResult:
+    layer_name: str
+    workspace: str
+    store_name: str
+    gpkg_path: str
+    source_layer: str
+    published_feature_type: str
+    upload_response: dict[str, Any]
+    publish_response: dict[str, Any]
+    wfs_url: str
+    wms_url: str
+    wfs_verified: bool
+    source_feature_count: int
+    wfs_feature_count: int | None
+    wfs_properties: list[str]
+    property_count: int
+
+
+def _geoserver_settings() -> tuple[str, str, str]:
+    from nrm_app.settings import GEOSERVER_PASSWORD, GEOSERVER_URL, GEOSERVER_USERNAME
+
+    return GEOSERVER_URL.rstrip("/"), GEOSERVER_USERNAME, GEOSERVER_PASSWORD
+
+
+def _auth() -> tuple[str, str]:
+    _, username, password = _geoserver_settings()
+    return username, password
+
+
+def _rest_url(path: str) -> str:
+    base_url, _, _ = _geoserver_settings()
+    return f"{base_url}/{path.lstrip('/')}"
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    ok: tuple[int, ...],
+    timeout: int = 120,
+    **kwargs: Any,
+) -> requests.Response:
+    response = requests.request(
+        method,
+        _rest_url(path),
+        auth=_auth(),
+        timeout=timeout,
+        **kwargs,
+    )
+    if response.status_code not in ok:
+        message = response.text or response.content.decode("utf-8", errors="replace")
+        raise GeoServerPublishError(
+            f"GeoServer {method.upper()} {path} failed with HTTP "
+            f"{response.status_code}: {message[:1000]}"
+        )
+    return response
+
+
+def geoserver_wfs_url(workspace: str, layer_name: str) -> str:
+    """Build a WFS GeoJSON URL for a published layer."""
+
+    base_url, _, _ = _geoserver_settings()
+    return (
+        f"{base_url}/{workspace}/ows?service=WFS&version=1.0.0&request=GetFeature&"
+        f"typeName={workspace}:{layer_name}&outputFormat=application/json"
+    )
+
+
+def geoserver_wms_url(workspace: str, layer_name: str) -> str:
+    """Build a WMS GetMap base URL for a published layer."""
+
+    base_url, _, _ = _geoserver_settings()
+    return (
+        f"{base_url}/{workspace}/wms?service=WMS&version=1.1.0&request=GetMap&"
+        f"layers={workspace}:{layer_name}"
+    )
+
+
+def ensure_workspace_ready(workspace: str, *, create: bool = True) -> None:
+    """Ensure a workspace exists and has a matching namespace.
+
+    GeoServer can return an internal server error when a datastore is uploaded
+    into a workspace whose namespace is missing or mismatched. We check that
+    explicitly before upload so pipeline tests fail with an actionable message.
+    """
+
+    workspace_path = f"rest/workspaces/{workspace}.json"
+    namespace_path = f"rest/namespaces/{workspace}.json"
+    workspace_response = requests.get(
+        _rest_url(workspace_path),
+        auth=_auth(),
+        headers={"Accept": "application/json"},
+        timeout=60,
+    )
+    if workspace_response.status_code == 404 and create:
+        body = f"<workspace><name>{escape(workspace)}</name></workspace>"
+        _request(
+            "post",
+            "rest/workspaces",
+            ok=(201,),
+            data=body,
+            headers={"Content-Type": "text/xml"},
+            timeout=60,
+        )
+    elif workspace_response.status_code != 200:
+        raise GeoServerPublishError(
+            f"GeoServer workspace `{workspace}` is not readable: "
+            f"HTTP {workspace_response.status_code}: {workspace_response.text[:500]}"
+        )
+
+    namespace_response = requests.get(
+        _rest_url(namespace_path),
+        auth=_auth(),
+        headers={"Accept": "application/json"},
+        timeout=60,
+    )
+    if namespace_response.status_code == 200:
+        return
+    if namespace_response.status_code != 404:
+        raise GeoServerPublishError(
+            f"GeoServer namespace `{workspace}` is not readable: "
+            f"HTTP {namespace_response.status_code}: {namespace_response.text[:500]}"
+        )
+    raise GeoServerPublishError(
+        f"GeoServer workspace `{workspace}` exists but namespace `{workspace}` "
+        "does not. Use a workspace with a matching namespace, or repair the "
+        "GeoServer catalog before publishing."
+    )
+
+
+def delete_datastore(workspace: str, store_name: str) -> None:
+    """Delete a vector datastore if present."""
+
+    response = requests.delete(
+        _rest_url(f"rest/workspaces/{workspace}/datastores/{store_name}"),
+        auth=_auth(),
+        params={"recurse": "true"},
+        timeout=60,
+    )
+    if response.status_code not in (200, 202, 404):
+        raise GeoServerPublishError(
+            f"Could not delete GeoServer datastore `{workspace}:{store_name}`: "
+            f"HTTP {response.status_code}: {response.text[:500]}"
+        )
+
+
+def _gpkg_feature_layers(gpkg_path: Path) -> list[str]:
+    with sqlite3.connect(gpkg_path) as connection:
+        return [
+            row[0]
+            for row in connection.execute(
+                "SELECT table_name FROM gpkg_contents WHERE data_type = 'features' "
+                "ORDER BY table_name"
+            ).fetchall()
+        ]
+
+
+def _resolve_source_layer(gpkg_path: Path, source_layer: str | None) -> str:
+    layers = _gpkg_feature_layers(gpkg_path)
+    if source_layer:
+        if source_layer not in layers:
+            raise GeoServerPublishError(
+                f"GeoPackage layer `{source_layer}` was not found in {gpkg_path}. "
+                f"Available layers: {layers}"
+            )
+        return source_layer
+    if len(layers) != 1:
+        raise GeoServerPublishError(
+            f"GeoPackage {gpkg_path} has {len(layers)} feature layers. "
+            "Pass source_layer explicitly."
+        )
+    return layers[0]
+
+
+def _gpkg_geometry_column(gpkg_path: Path, layer_name: str) -> str | None:
+    with sqlite3.connect(gpkg_path) as connection:
+        row = connection.execute(
+            "SELECT column_name FROM gpkg_geometry_columns WHERE table_name = ?",
+            (layer_name,),
+        ).fetchone()
+    return str(row[0]) if row else None
+
+
+def _gpkg_columns(gpkg_path: Path, layer_name: str) -> list[str]:
+    geometry_column = _gpkg_geometry_column(gpkg_path, layer_name)
+    with sqlite3.connect(gpkg_path) as connection:
+        rows = connection.execute(f'PRAGMA table_info("{layer_name}")').fetchall()
+    return [
+        str(row[1])
+        for row in rows
+        if str(row[1]) != geometry_column and not bool(row[5])
+    ]
+
+
+def _gpkg_row_count(gpkg_path: Path, layer_name: str) -> int:
+    with sqlite3.connect(gpkg_path) as connection:
+        return int(connection.execute(f'SELECT COUNT(*) FROM "{layer_name}"').fetchone()[0])
+
+
+def _upload_gpkg_store(gpkg_path: Path, *, workspace: str, store_name: str) -> dict[str, Any]:
+    with gpkg_path.open("rb") as handle:
+        response = _request(
+            "put",
+            f"rest/workspaces/{workspace}/datastores/{store_name}/file.gpkg"
+            "?configure=none&update=overwrite",
+            ok=(200, 201, 202),
+            data=handle,
+            headers={
+                "Content-Type": "application/geopackage+sqlite3",
+                "Accept": "application/json, application/xml",
+            },
+        )
+    return {
+        "status_code": response.status_code,
+        "text": response.text[:500],
+        "upload_format": "gpkg",
+    }
+
+
+def _publish_feature_type(
+    *,
+    workspace: str,
+    store_name: str,
+    source_layer: str,
+    layer_name: str,
+) -> dict[str, Any]:
+    body = (
+        "<featureType>"
+        f"<name>{escape(layer_name)}</name>"
+        f"<nativeName>{escape(source_layer)}</nativeName>"
+        f"<title>{escape(layer_name)}</title>"
+        "<srs>EPSG:4326</srs>"
+        "<enabled>true</enabled>"
+        "</featureType>"
+    )
+    response = _request(
+        "post",
+        f"rest/workspaces/{workspace}/datastores/{store_name}/featuretypes",
+        ok=(200, 201, 202),
+        data=body,
+        headers={"Content-Type": "text/xml", "Accept": "application/json, application/xml"},
+    )
+    return {"status_code": response.status_code, "text": response.text[:500]}
+
+
+def verify_wfs_layer(
+    *,
+    workspace: str,
+    layer_name: str,
+    expected_properties: list[str],
+    expected_count: int | None = None,
+) -> dict[str, Any]:
+    """Download a WFS GeoJSON sample and verify count/property availability."""
+
+    url = f"{geoserver_wfs_url(workspace, layer_name)}&maxFeatures=1"
+    response = requests.get(url, timeout=120)
+    if response.status_code != 200:
+        raise GeoServerPublishError(
+            f"WFS verification failed for `{workspace}:{layer_name}` with HTTP "
+            f"{response.status_code}: {response.text[:500]}"
+        )
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise GeoServerPublishError(
+            f"WFS verification for `{workspace}:{layer_name}` did not return JSON: "
+            f"{response.text[:500]}"
+        ) from exc
+    features = payload.get("features") or []
+    if not features and expected_count != 0:
+        raise GeoServerPublishError(
+            f"WFS verification for `{workspace}:{layer_name}` returned no features."
+        )
+    properties = list((features[0].get("properties") or {}).keys()) if features else []
+    missing = [name for name in expected_properties if name not in properties]
+    if missing:
+        raise GeoServerPublishError(
+            f"WFS verification for `{workspace}:{layer_name}` missed properties: "
+            f"{missing[:20]}"
+        )
+    total = payload.get("totalFeatures")
+    try:
+        total_count = int(total) if total is not None else None
+    except (TypeError, ValueError):
+        total_count = None
+    if expected_count is not None and total_count is not None and total_count != expected_count:
+        raise GeoServerPublishError(
+            f"WFS verification for `{workspace}:{layer_name}` returned "
+            f"{total_count} features, expected {expected_count}."
+        )
+    return {
+        "url": url,
+        "feature_count": total_count,
+        "sample_feature_count": len(features),
+        "properties": properties,
+    }
+
+
+def publish_gpkg_layer(
+    gpkg_path: str | Path,
+    *,
+    workspace: str,
+    layer_name: str,
+    overwrite: bool = True,
+    source_layer: str | None = None,
+) -> GeoServerPublishResult:
+    """Publish a local GeoPackage layer to GeoServer and verify WFS output."""
+
+    results = publish_gpkg_layers(
+        gpkg_path,
+        workspace=workspace,
+        store_name=layer_name,
+        layers={layer_name: source_layer},
+        overwrite=overwrite,
+    )
+    return results[layer_name]
+
+
+def publish_gpkg_layers(
+    gpkg_path: str | Path,
+    *,
+    workspace: str,
+    store_name: str,
+    layers: Mapping[str, str | None],
+    overwrite: bool = True,
+) -> dict[str, GeoServerPublishResult]:
+    """Publish several layers from one GeoPackage through one datastore.
+
+    ``layers`` maps each public GeoServer feature-type name to its source
+    GeoPackage layer. The package is uploaded once, then every feature type is
+    configured and independently verified through WFS.
+    """
+
+    gpkg_path = Path(gpkg_path)
+    if not gpkg_path.exists():
+        raise GeoServerPublishError(f"GeoPackage does not exist: {gpkg_path}")
+    if not layers:
+        raise GeoServerPublishError("At least one GeoPackage layer is required")
+
+    sources = {
+        str(layer_name): _resolve_source_layer(gpkg_path, source_layer)
+        for layer_name, source_layer in layers.items()
+    }
+    profiles = {
+        layer_name: (
+            _gpkg_columns(gpkg_path, source_layer),
+            _gpkg_row_count(gpkg_path, source_layer),
+        )
+        for layer_name, source_layer in sources.items()
+    }
+
+    ensure_workspace_ready(workspace)
+    if overwrite:
+        delete_datastore(workspace, store_name)
+
+    upload_response = _upload_gpkg_store(gpkg_path, workspace=workspace, store_name=store_name)
+    results: dict[str, GeoServerPublishResult] = {}
+    for layer_name, source_layer in sources.items():
+        source_properties, source_feature_count = profiles[layer_name]
+        publish_response = _publish_feature_type(
+            workspace=workspace,
+            store_name=store_name,
+            source_layer=source_layer,
+            layer_name=layer_name,
+        )
+        verification = verify_wfs_layer(
+            workspace=workspace,
+            layer_name=layer_name,
+            expected_properties=source_properties,
+            expected_count=source_feature_count,
+        )
+        results[layer_name] = GeoServerPublishResult(
+            layer_name=layer_name,
+            workspace=workspace,
+            store_name=store_name,
+            gpkg_path=gpkg_path.as_posix(),
+            source_layer=source_layer,
+            published_feature_type=layer_name,
+            upload_response=upload_response,
+            publish_response=publish_response,
+            wfs_url=geoserver_wfs_url(workspace, layer_name),
+            wms_url=geoserver_wms_url(workspace, layer_name),
+            wfs_verified=True,
+            source_feature_count=source_feature_count,
+            wfs_feature_count=verification["feature_count"],
+            wfs_properties=verification["properties"],
+            property_count=len(verification["properties"]),
+        )
+    return results
+
+
+def register_layer(
+    *,
+    dataset_name: str,
+    layer_name: str,
+    scope: Any,
+    workspace: str,
+    geoserver_url: str,
+    algorithm: str,
+    algorithm_version: str,
+    misc: dict[str, Any] | None = None,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Register a published layer in the Core Stack layer database.
+
+    Uses the same `save_layer_info_to_db` path as the GEE-backed pipelines, so
+    local pipeline layers appear alongside every other layer. The `Layer` model
+    is keyed on state/district/block, so only tehsil-scoped runs can register;
+    other scopes are reported as skipped rather than failing the run.
+
+    Never raises: the run has already succeeded by the time this is called, so
+    a database problem is reported in the result instead of losing the outputs.
+    """
+
+    level = str(getattr(scope, "level", "") or "").lower()
+    if level not in {"tehsil", "block"}:
+        return {"ok": False, "status": "skipped", "reason": f"layer registration needs a tehsil scope, got {level!r}"}
+    state, district, block = scope.state_name, scope.district_name, scope.tehsil_name
+    if not (state and district and block):
+        return {"ok": False, "status": "skipped", "reason": "scope is missing state, district, or tehsil name"}
+
+    try:
+        from computing.models import Dataset, LayerType
+        from computing.utils import save_layer_info_to_db, update_layer_sync_status
+
+        Dataset.objects.get_or_create(
+            name=dataset_name,
+            defaults={"layer_type": LayerType.VECTOR, "workspace": workspace},
+        )
+        layer_id = save_layer_info_to_db(
+            state=state,
+            district=district,
+            block=block,
+            layer_name=layer_name,
+            asset_id=geoserver_url,
+            dataset_name=dataset_name,
+            algorithm=algorithm,
+            algorithm_version=algorithm_version,
+            misc={"is_generated_locally": True, "geoserver_workspace": workspace, **(misc or {})},
+            is_override=overwrite,
+            is_gee_asset=False,
+        )
+        if not layer_id:
+            return {"ok": False, "status": "not_registered", "dataset": dataset_name,
+                    "reason": "save_layer_info_to_db returned no layer id (check state/district/block exist in the SOI tables)"}
+        update_layer_sync_status(layer_id=layer_id, sync_to_geoserver=True)
+        return {"ok": True, "status": "registered", "dataset": dataset_name, "layer_id": layer_id}
+    except Exception as exc:
+        return {"ok": False, "status": "registration_failed", "dataset": dataset_name,
+                "error_type": exc.__class__.__name__, "error": str(exc)[:500]}

--- a/utilities/pipelines/schema.py
+++ b/utilities/pipelines/schema.py
@@ -1,0 +1,283 @@
+"""Request parsing, config loading, and lightweight validation helpers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+import pandas as pd
+import yaml
+
+from .admin import AdminScope
+
+
+def coerce_bool(value: Any, default: bool = False) -> bool:
+    """Parse booleans from API, YAML, and form-style string values."""
+
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"1", "true", "t", "yes", "y", "on"}:
+            return True
+        if text in {"0", "false", "f", "no", "n", "off"}:
+            return False
+    return bool(value)
+
+
+def load_config(path: str | Path) -> dict[str, Any]:
+    """Load a YAML or JSON config file."""
+
+    path = Path(path)
+    text = path.read_text()
+    if path.suffix.lower() == ".json":
+        return json.loads(text)
+    return yaml.safe_load(text) or {}
+
+
+#: Standard values for the per-village `*_status` columns that every dataset
+#: pipeline writes right after the admin columns. They explain data
+#: availability to end users without needing the run metadata.
+STATUS_NO_VILLAGE_ID = "no village id available"
+STATUS_NO_DATA = "no data available for this village"
+STATUS_MATCHED = "matched"
+STATUS_COMPUTED = "computed"
+
+
+def status_column_config(config: Mapping[str, Any]) -> tuple[str | None, frozenset[str]]:
+    """Return the configured `*_status` column name and the outputs keeping it.
+
+    Pipelines configure this under `output_contract.status_column` with a
+    `name` and an `outputs` list (`gpkg` and/or `geoserver`). The GeoServer
+    layer is published from the GeoPackage, so both outputs share one frame.
+    """
+
+    contract = config.get("output_contract") or {}
+    spec = contract.get("status_column") or {}
+    name = spec.get("name")
+    if not name:
+        return None, frozenset()
+    return str(name), frozenset(str(item).lower() for item in spec.get("outputs") or ())
+
+
+@dataclass(frozen=True)
+class OutputOptions:
+    """Which artifacts a pipeline run writes.
+
+    The default mode writes a GeoPackage, README, metadata JSON (including
+    column descriptions, rename mappings, and EDA), a single links manifest,
+    and a GeoServer layer.
+    Each artifact can be turned off per request or per pipeline YAML
+    (`default_outputs`).
+    """
+
+    gpkg: bool = True
+    readme: bool = True
+    metadata: bool = True
+    geoserver: bool = True
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "OutputOptions":
+        merged = {field.name: getattr(cls, field.name) for field in cls.__dataclass_fields__.values()}
+        for key, value in dict(data or {}).items():
+            name = str(key)
+            if name in merged:
+                merged[name] = coerce_bool(value, merged[name])
+        return cls(**merged)
+
+
+def resolve_output_options(request: "StandardRequest", config: Mapping[str, Any]) -> OutputOptions:
+    """Resolve effective output flags: dataclass defaults, then the pipeline
+    YAML `default_outputs`, then per-request `outputs` overrides."""
+
+    merged: dict[str, Any] = dict(config.get("default_outputs") or {})
+    request_outputs = request.raw.get("outputs")
+    if isinstance(request_outputs, Mapping):
+        merged.update(request_outputs)
+    return OutputOptions.from_mapping(merged)
+
+
+@dataclass(frozen=True)
+class PublishOptions:
+    sync_to_geoserver: bool = True
+    overwrite: bool = True
+    register_layers: bool = True
+    use_pregenerated: bool = False
+    geoserver_workspace: str | None = None
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "PublishOptions":
+        values = dict(data or {})
+        return cls(
+            sync_to_geoserver=coerce_bool(values.get("sync_to_geoserver"), True),
+            overwrite=coerce_bool(values.get("overwrite"), True),
+            register_layers=coerce_bool(values.get("register_layers"), True),
+            use_pregenerated=coerce_bool(values.get("use_pregenerated"), False),
+            geoserver_workspace=str(values["geoserver_workspace"]) if values.get("geoserver_workspace") else None,
+        )
+
+
+def api_request_payload(data: Mapping[str, Any], *, overwrite: bool = True) -> dict[str, Any]:
+    """Normalize an API body into the standard request payload.
+
+    Two request shapes are supported. The simple shape matches the other
+    Core Stack layer APIs and implies a tehsil scope:
+
+        {"state": "jharkhand", "district": "dumka", "block": "masalia",
+         "sync_to_geoserver": true, "overwrite": true}
+
+    The structured shape addresses any scope level and toggles artifacts:
+
+        {"scope": {"level": "district", "state_name": ..., "district_name": ...},
+         "outputs": {"metadata": true}, "publish": {"sync_to_geoserver": false}}
+
+    `overwrite` is the pipeline's default when the body does not set it.
+    Raises ValueError when the body names no resolvable geography.
+    """
+
+    body = dict(data)
+    scope = body.get("scope")
+    if not isinstance(scope, Mapping):
+        scope = {
+            "level": body.get("level") or body.get("scope_level") or "tehsil",
+            "state_name": body.get("state_name") or body.get("state"),
+            "district_name": body.get("district_name") or body.get("district"),
+            "tehsil_name": body.get("tehsil_name") or body.get("block_name") or body.get("block"),
+            "village_ids": body.get("village_ids") or body.get("village_id"),
+        }
+    scope = {key: value for key, value in dict(scope).items() if value is not None}
+    scope.setdefault("level", "tehsil")
+    if not scope.get("state_name") and not scope.get("village_ids"):
+        raise ValueError("Provide state/district/block (or a scope object with state_name or village_ids).")
+
+    publish = dict(body.get("publish") or {})
+    for key, default in (
+        ("sync_to_geoserver", True),
+        ("overwrite", overwrite),
+        ("register_layers", True),
+        ("use_pregenerated", False),
+    ):
+        # Simple bodies carry publish flags at the top level.
+        publish.setdefault(key, body.get(key, default))
+
+    return {
+        "scope": scope,
+        "outputs": dict(body.get("outputs") or {}),
+        "publish": publish,
+    }
+
+
+@dataclass(frozen=True)
+class StandardRequest:
+    """Standard request object accepted by local pipeline implementations."""
+
+    scope: AdminScope
+    outputs: OutputOptions = field(default_factory=OutputOptions)
+    publish: PublishOptions = field(default_factory=PublishOptions)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "StandardRequest":
+        raw = dict(data)
+        scope_data = raw.get("scope") if isinstance(raw.get("scope"), Mapping) else raw
+        output_data = dict(raw.get("outputs") or {})
+        return cls(
+            scope=AdminScope.from_mapping(dict(scope_data)),
+            outputs=OutputOptions.from_mapping(output_data),
+            publish=PublishOptions.from_mapping(raw.get("publish")),
+            raw=raw,
+        )
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """A structured validation issue produced by schema checks."""
+
+    severity: str
+    field: str
+    message: str
+    count: int | None = None
+
+
+def require_columns(frame: pd.DataFrame, columns: Iterable[str]) -> list[ValidationIssue]:
+    """Return issues for missing required columns."""
+
+    present = set(frame.columns)
+    return [
+        ValidationIssue("error", column, f"Missing required column: {column}")
+        for column in columns
+        if column not in present
+    ]
+
+
+def validate_value_set(
+    frame: pd.DataFrame,
+    *,
+    columns: Iterable[str],
+    allowed_values: Iterable[Any],
+    allow_null: bool = True,
+) -> list[ValidationIssue]:
+    """Validate that selected columns contain only configured values."""
+
+    allowed = set(allowed_values)
+    issues: list[ValidationIssue] = []
+    for column in columns:
+        if column not in frame.columns:
+            issues.append(ValidationIssue("error", column, f"Missing value-domain column: {column}"))
+            continue
+        series = frame[column]
+        if allow_null:
+            series = series.dropna()
+        invalid = ~series.isin(allowed)
+        count = int(invalid.sum())
+        if count:
+            issues.append(
+                ValidationIssue(
+                    "error",
+                    column,
+                    f"Column contains values outside {sorted(allowed)}",
+                    count,
+                )
+            )
+    return issues
+
+
+def validate_numeric_range(
+    frame: pd.DataFrame,
+    *,
+    columns: Iterable[str],
+    minimum: float | None = None,
+    maximum: float | None = None,
+    allow_null: bool = True,
+) -> list[ValidationIssue]:
+    """Validate numeric columns against optional min/max bounds."""
+
+    issues: list[ValidationIssue] = []
+    for column in columns:
+        if column not in frame.columns:
+            issues.append(ValidationIssue("error", column, f"Missing numeric column: {column}"))
+            continue
+        values = pd.to_numeric(frame[column], errors="coerce")
+        invalid = values.isna() & frame[column].notna()
+        if not allow_null:
+            invalid = invalid | values.isna()
+        if minimum is not None:
+            invalid = invalid | (values < minimum)
+        if maximum is not None:
+            invalid = invalid | (values > maximum)
+        count = int(invalid.sum())
+        if count:
+            issues.append(ValidationIssue("error", column, "Column failed numeric range validation", count))
+    return issues
+
+
+def columns_ending_with(frame: pd.DataFrame, suffix: str) -> list[str]:
+    """Return columns whose names end with a suffix."""
+
+    return [column for column in frame.columns if str(column).endswith(suffix)]

--- a/utilities/pipelines/tabular.py
+++ b/utilities/pipelines/tabular.py
@@ -1,0 +1,202 @@
+"""CSV and SQLite-sidecar helpers for keyed local datasets."""
+
+from __future__ import annotations
+
+import csv
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import pandas as pd
+
+from .gpkg import IndexSpec, column_expression, ensure_indexes, quote_identifier
+
+
+def csv_header(path: str | Path) -> list[str]:
+    """Read only the header row from a CSV file."""
+
+    with Path(path).open(newline="") as handle:
+        return next(csv.reader(handle))
+
+
+def default_sidecar_path(csv_path: str | Path) -> Path:
+    """Return the default SQLite sidecar path for a CSV source."""
+
+    csv_path = Path(csv_path)
+    return csv_path.with_suffix(csv_path.suffix + ".sqlite")
+
+
+def _source_signature(path: Path) -> tuple[int, int]:
+    stat = path.stat()
+    return stat.st_size, stat.st_mtime_ns
+
+
+@dataclass
+class CSVSQLiteSidecar:
+    """Materialize a large keyed CSV into a local SQLite sidecar table."""
+
+    csv_path: str | Path
+    table_name: str
+    key_columns: tuple[str, ...]
+    sidecar_path: str | Path | None = None
+    source_columns: tuple[str, ...] | None = None
+    chunksize: int = 50_000
+
+    def __post_init__(self) -> None:
+        self.csv_path = Path(self.csv_path)
+        self.sidecar_path = Path(self.sidecar_path or default_sidecar_path(self.csv_path))
+
+    def is_fresh(self) -> bool:
+        """Return whether the sidecar exists and matches the CSV size/mtime."""
+
+        if not self.sidecar_path.exists():
+            return False
+        source_size, source_mtime_ns = _source_signature(self.csv_path)
+        with sqlite3.connect(self.sidecar_path) as connection:
+            if not self._metadata_table_exists(connection):
+                return False
+            try:
+                row = connection.execute(
+                    """
+                    SELECT source_size, source_mtime_ns, materialized_columns
+                    FROM local_pipeline_sidecar_metadata
+                    WHERE source_path = ?
+                    """,
+                    (self.csv_path.as_posix(),),
+                ).fetchone()
+            except sqlite3.OperationalError:
+                return False
+        expected_columns = tuple(dict.fromkeys([*(self.source_columns or ()), *self.key_columns]))
+        columns_match = True
+        if expected_columns:
+            materialized_columns = tuple((row[2] or "").split(",")) if row and row[2] else ()
+            columns_match = set(expected_columns).issubset(materialized_columns)
+        return bool(row and int(row[0]) == source_size and int(row[1]) == source_mtime_ns and columns_match)
+
+    def materialize(self, *, force: bool = False) -> dict[str, Any]:
+        """Create or refresh the SQLite sidecar table from CSV chunks."""
+
+        if not force and self.is_fresh():
+            return {"sidecar_path": self.sidecar_path.as_posix(), "refreshed": False}
+
+        self.sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+        if self.sidecar_path.exists():
+            self.sidecar_path.unlink()
+
+        rows = 0
+        first_chunk = True
+        with sqlite3.connect(self.sidecar_path) as connection:
+            connection.execute("PRAGMA journal_mode = WAL")
+            connection.execute("PRAGMA temp_store = MEMORY")
+            read_columns = list(dict.fromkeys([*(self.source_columns or ()), *self.key_columns]))
+            for chunk in pd.read_csv(
+                self.csv_path,
+                chunksize=self.chunksize,
+                low_memory=False,
+                usecols=read_columns or None,
+            ):
+                if first_chunk:
+                    missing = [column for column in self.key_columns if column not in chunk.columns]
+                    if missing:
+                        raise ValueError(f"CSV is missing key column(s): {missing}")
+                chunk.to_sql(self.table_name, connection, if_exists="replace" if first_chunk else "append", index=False)
+                rows += len(chunk)
+                first_chunk = False
+
+            self._write_metadata(connection, rows, tuple(chunk.columns) if rows else tuple(read_columns))
+            connection.commit()
+
+        self.ensure_key_indexes()
+        return {"sidecar_path": self.sidecar_path.as_posix(), "refreshed": True, "rows": rows}
+
+    def ensure_key_indexes(self) -> list[str]:
+        """Create exact key indexes for configured key columns."""
+
+        specs = tuple(
+            IndexSpec(
+                name=f"idx_{self.table_name}_{column}_lookup",
+                table=self.table_name,
+                expressions=(column_expression(column),),
+            )
+            for column in self.key_columns
+        )
+        return ensure_indexes(self.sidecar_path, specs)
+
+    def fetch_by_values(
+        self,
+        key_column: str,
+        values: Iterable[Any],
+        *,
+        columns: Sequence[str] | None = None,
+    ) -> pd.DataFrame:
+        """Fetch sidecar rows by a configured key column."""
+
+        values = [value for value in values if value is not None and value == value]
+        if not values:
+            return pd.DataFrame(columns=list(columns or []))
+        if not self.is_fresh():
+            self.materialize()
+        select_columns = "*" if columns is None else ", ".join(quote_identifier(col) for col in columns)
+        with sqlite3.connect(self.sidecar_path) as connection:
+            connection.execute("PRAGMA temp_store = MEMORY")
+            connection.execute("DROP TABLE IF EXISTS temp.local_pipeline_requested_values")
+            connection.execute("CREATE TEMP TABLE local_pipeline_requested_values (value PRIMARY KEY)")
+            connection.executemany(
+                "INSERT OR IGNORE INTO local_pipeline_requested_values (value) VALUES (?)",
+                [(value,) for value in values],
+            )
+            return pd.read_sql_query(
+                f"""
+                SELECT {select_columns}
+                FROM {quote_identifier(self.table_name)}
+                WHERE {quote_identifier(key_column)} IN (
+                    SELECT value FROM local_pipeline_requested_values
+                )
+                """,
+                connection,
+            )
+
+    def _metadata_table_exists(self, connection: sqlite3.Connection) -> bool:
+        return (
+            connection.execute(
+                """
+                SELECT 1 FROM sqlite_master
+                WHERE type = 'table' AND name = 'local_pipeline_sidecar_metadata'
+                """
+            ).fetchone()
+            is not None
+        )
+
+    def _write_metadata(self, connection: sqlite3.Connection, rows: int, materialized_columns: tuple[str, ...]) -> None:
+        source_size, source_mtime_ns = _source_signature(self.csv_path)
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS local_pipeline_sidecar_metadata (
+                source_path TEXT PRIMARY KEY,
+                source_size INTEGER NOT NULL,
+                source_mtime_ns INTEGER NOT NULL,
+                table_name TEXT NOT NULL,
+                row_count INTEGER NOT NULL,
+                materialized_columns TEXT,
+                created_at_utc TEXT NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO local_pipeline_sidecar_metadata
+            (source_path, source_size, source_mtime_ns, table_name, row_count, materialized_columns, created_at_utc)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                self.csv_path.as_posix(),
+                source_size,
+                source_mtime_ns,
+                self.table_name,
+                int(rows),
+                ",".join(materialized_columns),
+                datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+            ),
+        )

--- a/utilities/pipelines/unicode.py
+++ b/utilities/pipelines/unicode.py
@@ -1,0 +1,63 @@
+"""Small UTF-8/Unicode normalization helpers for final pipeline outputs."""
+
+from __future__ import annotations
+
+import unicodedata
+from collections.abc import Mapping
+from typing import Any
+
+import pandas as pd
+
+
+def normalize_unicode_text(value: str) -> str:
+    """Return safe NFC text while preserving Indic and other scripts.
+
+    Invalid surrogate code points become the Unicode replacement character.
+    NUL and non-whitespace C0 control characters are removed because they are
+    invalid or unreliable in GeoPackage and JSON text fields.
+    """
+
+    safe = "".join(
+        "\ufffd" if 0xD800 <= ord(character) <= 0xDFFF else character
+        for character in value
+    )
+    normalized = unicodedata.normalize("NFC", safe)
+    return "".join(
+        character
+        for character in normalized
+        if character in {"\t", "\n", "\r"}
+        or not unicodedata.category(character).startswith("C")
+    )
+
+
+def normalize_unicode_frame(frame: pd.DataFrame):
+    """Normalize all textual cells in a DataFrame/GeoDataFrame in one call."""
+
+    normalized = frame.copy()
+    for position in range(len(normalized.columns)):
+        series = normalized.iloc[:, position]
+        if str(series.dtype) not in {"object", "string"}:
+            continue
+        normalized.iloc[:, position] = series.map(
+            lambda value: normalize_unicode_text(value) if isinstance(value, str) else value
+        )
+    return normalized
+
+
+def normalize_unicode_data(value: Any) -> Any:
+    """Recursively normalize strings in JSON-compatible metadata structures."""
+
+    if isinstance(value, str):
+        return normalize_unicode_text(value)
+    if isinstance(value, Mapping):
+        return {
+            normalize_unicode_text(str(key)): normalize_unicode_data(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [normalize_unicode_data(item) for item in value]
+    if isinstance(value, tuple):
+        return [normalize_unicode_data(item) for item in value]
+    if isinstance(value, set):
+        return [normalize_unicode_data(item) for item in sorted(value, key=str)]
+    return value


### PR DESCRIPTION
## Summary

Adds the finalized reusable framework for fast, modular local geospatial pipelines:

- indexed administrative-scope selection;
- direct SQLite/GeoPackage reads and keyed CSV-to-SQLite indexes;
- cache validation;
- Fiona-based GeoPackage output; (No `pyogrio`)
- direct multi-layer GeoServer GeoPackage publication;
- WFS row-count and property verification;
- Layer database registration metadata;
- Unicode NFC normalization;
- GeoLibre project and clickable HTML generation;
- standard metadata and links-manifest generation.

This also adds the Mission Antyodaya and Livestock production GeoServer workspace constants alongside the existing Facilities workspace constant.

## Output contract

- GeoPackage is the standard local data output; CSV and STAC generation are removed.
- Metadata includes column descriptions, optional report-facing rename mappings, and EDA.
- One `<layer>.links.json` manifest records local, GeoServer, and GeoLibre resources.
- Indic and other Unicode text is normalized before final writes.
- GeoLibre references live WFS layers without copying feature data.

## Scope

This PR contains only the reusable shared framework and workspace constants. Dataset pipelines, API endpoints, test suites, generated data, and local development tooling are intentionally excluded and will follow through separate sequential PRs.

## Validation

- 13/13 focused shared-module tests passed.
- All changed Python modules compile successfully.
- All files passed UTF-8 and line-ending consistency checks.
- The restored shared module is byte-identical to the finalized UAT-verified source.
- GeoLibre upstream compatibility was rechecked against the current official source; project format `0.2.0` and all adapter-dependent contracts remain compatible.