### PR TITLE
Add live facilities points and village proximity pipeline

### DIFF
--- a/computing/api.py
+++ b/computing/api.py
@@ -90,7 +90,8 @@ from .misc.catchment_area import generate_catchment_area_singleflow
 from .zoi_layers.zoi import generate_zoi
 from .mws.mws_connectivity import generate_mws_connectivity_data
 from .mws.mws_centroid import generate_mws_centroid_data
-from .misc.facilities_proximity import generate_facilities_proximity_task
+from .misc.facilities import generate_facilities_proximity_task
+from utilities.pipelines import api_request_payload
 from .misc.antyodaya import generate_antyodaya_layer_task
 from .misc.livestocks import generate_livestocks_layer_task
 from .misc.digital_elevation_model import generate_dem_layer
@@ -1579,16 +1580,19 @@ def generate_mws_centroid(request):
 def generate_facilities_proximity(request):
     print("Inside generate_facilities_proximity API.")
     try:
-        state = request.data.get("state").lower()
-        district = request.data.get("district").lower()
-        block = request.data.get("block").lower()
-        gee_account_id = request.data.get("gee_account_id")
+        payload = api_request_payload(
+            request.data.dict() if hasattr(request.data, "dict") else dict(request.data),
+            overwrite=True,
+        )
         generate_facilities_proximity_task.apply_async(
-            args=[state, district, block, gee_account_id], queue="nrm"
+            kwargs={"payload": payload},
+            queue="nrm",
         )
         return Response(
-            {"Success": "Successfully initiated"}, status=status.HTTP_200_OK
+            {"Success": "Successfully initiated", "request": payload}, status=status.HTTP_200_OK
         )
+    except ValueError as e:
+        return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
     except Exception as e:
         print("Exception in generate_facilities_proximity api :: ", e)
         return Response({"Exception": e}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/computing/misc/facilities/README.md
+++ b/computing/misc/facilities/README.md
@@ -1,0 +1,184 @@
+# Facility Proximity & Village Service Access Dataset
+
+## Why Service Proximity Matters
+
+Distance is one of the most decisive and least visible determinants of rural
+well-being. A school that exists but is 12 km away is, for a six-year-old,
+a school that does not exist. Health outcomes, learning continuity, savings
+behaviour, the price a farmer receives for produce, and whether milk reaches
+a market before it spoils are all shaped by how far a household is from the
+nearest working facility. Human development programmes usually track whether
+facilities exist; this dataset instead measures **how reachable they are,
+village by village** — which is what planning, siting, and prioritisation
+decisions actually need.
+
+For Core Stack ([core-stack.org](https://core-stack.org)) this layer connects
+people to services the way the hydrology layers connect land to water: it
+turns point locations of schools, health centres, banks, ration shops,
+markets, and agri-industry units into per-village access measures that can be
+read alongside Antyodaya development indices, livestock counts, and watershed
+data.
+
+## Where the Facility Points Come From
+
+Public facility registries were cleaned and consolidated into one pan-India
+Core Stack GeoPackage (`cs_pan_india_facilities.gpkg`, ~4.19 million facility
+points), keeping one row per physical facility with a stable identifier:
+
+- **Education**: UDISE-style school records (primary through higher
+  secondary) and AISHE records for colleges and university-type institutions.
+- **Health**: sub-centres, PHCs, CHCs, district hospitals, and
+  specialist/tertiary hospitals from public health facility registries.
+- **Food security**: PDS fair price shops.
+- **Finance**: Common Service Centres, bank mitras/business correspondents,
+  bank branches, and ATMs.
+- **Agriculture**: APMC mandis and agri-industry units (markets and trading,
+  storage and warehousing, distribution utilities, processing, industrial
+  manufacturing, co-operatives and societies, dairy and animal husbandry, and
+  agriculture support infrastructure).
+
+Each source's cleaned file, identifier column, and per-class description are
+recorded in `facility_classifications.yaml`; the full build metadata (row
+counts, coverage, per-column EDA of the pan-India asset) lives in
+`utilities/scripts/facilities_utils/facilities_column_metadata.yaml`.
+
+## The Classification: L1 → L2 → L3
+
+Facility points carry a three-level classification, defined and documented in
+`facility_classifications.yaml`:
+
+- **L3 facility classes** are concrete service types — `school_primary`,
+  `health_phc`, `bank_atm`, `apmc`, and so on (25 classes).
+- **L2 filter groups** collapse related L3 classes into one *access
+  question* — "is essential education reachable?", "is advanced health
+  reachable?" (11 groups).
+- **L1 domains** organise groups by sector: education, health, food
+  security, finance, agriculture.
+
+The interesting design decision is **how a group summarises its members**,
+because different access questions have different logic:
+
+- **`max` — baseline bundles.** Essential education requires primary,
+  upper-primary, *and* secondary access; essential health requires both
+  sub-centre and PHC; financial inclusion requires CSC, bank mitra, branch,
+  and ATM. For a bundle, the farthest required member is the bottleneck, so
+  the group distance is the *maximum* — a low value means the whole baseline
+  package is nearby.
+- **`min` — opportunity gateways.** Higher education, advanced health,
+  markets, and post-harvest infrastructure are satisfied by *any one*
+  member: reaching any college or higher-secondary school opens the
+  higher-education gateway. The group distance is the *minimum* over the
+  alternatives.
+- **`direct` — single services.** PDS, cooperatives, dairy/animal husbandry
+  support, and agriculture support infrastructure map one-to-one to a single
+  L3 class.
+
+This is why the category columns can be read as one number per service
+domain without hiding what drives them: every `*_cat_distance_km` value can
+be traced back to the `nearest_*` facility columns beneath it.
+
+## What the Pipeline Computes
+
+At request time, for the villages in the requested scope:
+
+1. Village polygons are read from `cs_admin_standard.gpkg` (SQLite-indexed;
+   only the requested rows are loaded).
+2. Facility candidates are read from the pan-India GeoPackage using its
+   R-tree over a modestly expanded bounding box; classes still missing get a
+   wider supplemental search, so remote services like district hospitals are
+   found without loading millions of rows.
+3. Facilities inside the scope are recorded as the **inventory**.
+4. For each village (represented by a point inside its polygon) and each L3
+   class, the nearest facility is found with a KD-tree and its great-circle
+   distance in km is computed.
+5. L3 results are collapsed into the L2 category distances using the
+   `max`/`min`/`direct` rollups above.
+
+```mermaid
+flowchart TD
+    A[API or CLI request] --> B[Resolve scope in cs_admin_standard.gpkg]
+    B --> C[Read selected village geometries]
+    C --> D[Read facility candidates using GeoPackage R-tree]
+    D --> E[Spatially assign inventory facilities inside selected geography]
+    E --> F[Build KD-tree by L3 facility class]
+    F --> G[Find nearest facility per village and L3 class]
+    G --> H[Collapse nearest L3 rows into L2 category distances]
+    H --> I[Write village GPKG, two-layer points GPKG, README, metadata, links]
+    I --> J{GeoServer enabled?}
+    J -- yes --> K[Publish local GPKG]
+    J -- no --> L[Return local output bundle]
+```
+
+## Output Structure
+
+| Artifact | Contents |
+| --- | --- |
+| `<layer>.gpkg` | Village properties: geometries plus the full machine columns (`l2_*`, `l3_*` distances, facility identifiers, inside-scope flags). |
+| `<layer>.facility_points.gpkg` | Exactly two point layers: `tehsil_facility_collection` and `village_nearest_facility_collection`. |
+| `README.md` | One run summary with column reference and optional rename targets. |
+| `<layer>.run_metadata.json` | One metadata file with request, effective outputs, per-layer column descriptions, `column_rename_mapping`, and EDA. |
+| `<layer>.links.json` | One manifest containing local paths plus every GeoServer link. |
+| GeoServer layers | Village properties and both point layers, published as three separately addressable feature types. |
+
+Machine-to-report rename suggestions are derived from the classification
+structure and recorded in metadata without changing stable GeoServer fields.
+Targets are overridable through `output_contract.l2_distance_columns` in
+`facilities_pipeline.yaml` (for example `apmc_access` publishes as
+`market_cat_distance_km`). Column descriptions come from the description
+templates in `facility_classifications.yaml`, so README and metadata
+always agree.
+
+The `facilities_status` column sits right after the admin columns in every
+output and records data availability per village: `computed`,
+`no village id available`, or `no data available for this village`. It is
+configured under `output_contract.status_column` in the pipeline YAML and can
+be dropped from any artifact by removing that output from its `outputs` list.
+
+## What You Can Do With It
+
+- Rank villages of a block by `essential_education_cat_distance_km` to see
+  where the full schooling ladder is out of daily reach.
+- Map `advanced_health_cat_distance_km` to find emergency-care deserts and
+  test ambulance or referral-transport routings.
+- Cross `financial_inclusion_cat_distance_km` with Antyodaya SHG-credit
+  categories to separate "no access" from "access but no uptake".
+- Combine `dairy_livestock_cat_distance_km` with the livestock census layer:
+  many large animals plus distant dairy support is a concrete market-linkage
+  opportunity.
+- Use the inventory layer to audit what exists *inside* a panchayat before a
+  gram sabha planning session.
+
+## Use with Caution
+
+- Distances are **great-circle approximations from a village representative
+  point**, not travel time or road distance; terrain and rivers can make a
+  near facility far in practice.
+- Facilities outside the requested geography appear in nearest-service
+  results whenever they are the closest option — that is by design.
+- Source registries have different vintages and location accuracy;
+  a nearest facility may have closed, moved, or be non-functional.
+- Point presence says nothing about staffing, stock, or quality of service.
+
+## Running It
+
+```bash
+# API (Django + celery running)
+# Simple body, same as the other Core Stack layer APIs (implies tehsil scope)
+POST /api/v1/generate_facilities_proximity/
+{"state": "madhya pradesh", "district": "damoh", "block": "hatta",
+ "sync_to_geoserver": true, "overwrite": true}
+
+# Structured body, for any scope level and per-artifact output control
+POST /api/v1/generate_facilities_proximity/
+{"scope": {"level": "district", "state_name": "MADHYA PRADESH",
+           "district_name": "DAMOH"},
+ "outputs": {"metadata": true},
+ "publish": {"sync_to_geoserver": true}}
+
+# CLI
+python -m computing.misc.facilities --state "MADHYA PRADESH" --district DAMOH --tehsil HATTA --no-geoserver
+```
+
+Outputs (`gpkg`, `readme`, `metadata`, `geoserver`) can each be
+toggled per request under `outputs`, or by default in
+`facilities_pipeline.yaml` `default_outputs`.

--- a/computing/misc/facilities/__init__.py
+++ b/computing/misc/facilities/__init__.py
@@ -1,0 +1,13 @@
+"""Facilities local runtime pipeline."""
+
+from .pipeline import (
+    generate_facilities_proximity_task,
+    run_facilities_pipeline,
+    run_facilities_request,
+)
+
+__all__ = [
+    "generate_facilities_proximity_task",
+    "run_facilities_pipeline",
+    "run_facilities_request",
+]

--- a/computing/misc/facilities/__main__.py
+++ b/computing/misc/facilities/__main__.py
@@ -1,0 +1,7 @@
+"""Command-line entrypoint for the facilities local pipeline."""
+
+from .pipeline import main
+
+
+if __name__ == "__main__":
+    main()

--- a/computing/misc/facilities/facilities_pipeline.yaml
+++ b/computing/misc/facilities/facilities_pipeline.yaml
@@ -1,0 +1,81 @@
+name: facilities
+title: Facilities and Village Service Proximity
+description: >
+  Live local facilities inventory and nearest-service pipeline built from
+  cs_pan_india_facilities.gpkg and cs_admin_standard.gpkg.
+
+sources:
+  admin_gpkg: data/admin-boundary/cs_admin_standard.gpkg
+  admin_layer: cs_admin_standard
+  facilities_gpkg: data/facilities/outputs/cs_pan_india_facilities.gpkg
+  facilities_layer: facilities
+  taxonomy_table: facility_taxonomy
+  classification_yaml: computing/misc/facilities/facility_classifications.yaml
+
+output:
+  root: data/tests/outputs/facilities
+  layer_prefix: facilities
+  geoserver_workspace: testworkspace
+  # Dataset row used when registering published layers in the Layer database.
+  dataset_name: Facilities Proximity
+  points_dataset_name: Facilities Points
+
+default_outputs:
+  gpkg: true
+  readme: true
+  metadata: true
+  geoserver: true
+
+# Category distance rename targets default to `<group>_cat_distance_km`;
+# `l2_distance_columns` overrides the generated target where reports expect a
+# different one. The mapping is metadata only; stored GeoServer fields remain
+# stable machine names.
+# `status_column` places a per-village data-availability marker right after
+# the admin columns in every listed output. Remove an entry from `outputs`
+# to drop the column from that artifact (the GeoServer layer is published
+# from the GeoPackage, so `gpkg` and `geoserver` share one frame).
+output_contract:
+  status_column:
+    name: facilities_status
+    outputs: [gpkg, geoserver]
+  l2_distance_columns:
+    apmc_access: market_cat_distance_km
+    cooperative: cooperative_societies_cat_distance_km
+    livestock: dairy_livestock_cat_distance_km
+
+search:
+  base_expansion_degrees: 0.25
+  supplemental_expansion_degrees: 2.0
+  earth_radius_km: 6371.0088
+
+facility_columns:
+  - facility_uid
+  - facility_name
+  - facility_code
+  - latitude
+  - longitude
+  - class_l1_domain
+  - class_l2_filter_group
+  - class_l3_facility_class
+  - class_l4_facility_subtype
+  - class_k1
+  - class_k2
+  - class_k3
+  - class_k4
+  - class_k5
+  - class_k6
+  - class_k7
+  - class_k8
+  - urban_rural
+  - pincode
+  - establishment_year
+  - district_lgd
+  - village_census11
+  - village_name
+  - membership_count
+
+readme:
+  cautions:
+    - Nearest-service outputs are computed from facility points and village representative points.
+    - Facilities outside the requested geography may appear in nearest-service outputs when they are the closest service for a selected village.
+    - Distance values are great-circle approximations in kilometers.

--- a/computing/misc/facilities/facility_classifications.yaml
+++ b/computing/misc/facilities/facility_classifications.yaml
@@ -1,0 +1,332 @@
+name: facilities_service_classification
+version: 2
+description: >
+  Classification, access-rollup, and column-description schema for the Core
+  Stack facilities runtime pipeline. L3 classes identify the nearest concrete
+  facility type. L2 groups collapse related L3 classes into a simpler access
+  measure for reports, CSV exports, and village-level interpretation. The
+  per-class source details and descriptions were consolidated from
+  utilities/scripts/facilities_utils/facilities_column_metadata.yaml so that
+  runtime outputs can carry consistent human-readable column documentation.
+
+source_asset:
+  facilities_gpkg: data/facilities/outputs/cs_pan_india_facilities.gpkg
+  facility_rows: 4192404
+  built_by: utilities/scripts/facilities_utils/build_pan_india_facilities.py
+  column_metadata: utilities/scripts/facilities_utils/facilities_column_metadata.yaml
+  source_datasets:
+    - school
+    - college
+    - universities
+    - health_center
+    - pds
+    - csc
+    - bank_mitra
+    - bank_branch
+    - bank_atm
+    - apmc
+    - agri_industry
+
+access_rollup_notes:
+  min: >
+    Use the nearest available L3 class when any one member of the group can
+    satisfy the access question. This is used for groups such as advanced
+    health, higher education, market access, and post-harvest infrastructure.
+  max: >
+    Use the farthest required L3 class when a village should have access to all
+    member services to be considered fully covered. This is used for grouped
+    essentials such as primary/upper-primary/secondary schooling, basic health,
+    and financial inclusion.
+  direct: >
+    Use the only configured L3 class directly. This is used when the L2 group
+    has one concrete service class.
+
+# Templates used to build the runtime column dictionary. `{label}` is replaced
+# with the L3 class label or L2 group label at runtime.
+output_column_descriptions:
+  status: >-
+    Row computation status: `computed` when nearest services were resolved,
+    `no village id available` when the admin row lacks a village identifier,
+    and `no data available for this village` when no facility candidates were
+    found near the requested scope.
+  category_distance:
+    max: >-
+      {label} bundle distance in km: the farthest of the required member
+      services, so a low value means the full baseline bundle is nearby.
+    min: >-
+      {label} gateway distance in km: the nearest of the alternative member
+      services, since reaching any one of them opens this access.
+    direct: >-
+      {label} distance in km to the single service class in this group.
+  nearest_facility: >-
+    Nearest {label}: compact facility detail with name, subtype, code, and
+    whether it lies inside the requested boundary.
+  nearest_distance: >-
+    Great-circle distance in km from the village locality point to the
+    nearest {label}.
+
+l2_groups:
+  - key: essential_education
+    label: Essential Education Access
+    class_l1_domain: education
+    rollup: max
+    explanation: Distance to the farthest required school tier among primary, upper-primary, and secondary access.
+  - key: higher_education
+    label: Higher Education Access
+    class_l1_domain: education
+    rollup: min
+    explanation: Distance to the nearest higher-education option among higher-secondary school, college, and university-type institutions.
+  - key: essential_health
+    label: Essential Health Access
+    class_l1_domain: health
+    rollup: max
+    explanation: Distance to the farthest required basic health tier among sub-centre and PHC access.
+  - key: advanced_health
+    label: Advanced Health Access
+    class_l1_domain: health
+    rollup: min
+    explanation: Distance to the nearest advanced health option among CHC, district hospital, and specialist/tertiary hospitals.
+  - key: essential_services
+    label: Essential Services Access
+    class_l1_domain: food_security
+    rollup: direct
+    explanation: Distance to the nearest public distribution system point.
+  - key: financial_inclusion
+    label: Financial Inclusion Access
+    class_l1_domain: finance
+    rollup: max
+    explanation: Distance to the farthest required financial inclusion service among CSC, bank mitra, branch, and ATM access.
+  - key: apmc_access
+    label: APMC And Market Access
+    class_l1_domain: agriculture
+    rollup: min
+    explanation: Distance to the nearest market or trading access point.
+  - key: post_harvest
+    label: Post-Harvest Infrastructure Access
+    class_l1_domain: agriculture
+    rollup: min
+    explanation: Distance to the nearest post-harvest infrastructure option across storage, distribution, processing, and industrial manufacturing.
+  - key: cooperative
+    label: Cooperative Access
+    class_l1_domain: agriculture
+    rollup: direct
+    explanation: Distance to the nearest cooperative or society.
+  - key: livestock
+    label: Livestock Support Access
+    class_l1_domain: agriculture
+    rollup: direct
+    explanation: Distance to the nearest dairy or animal husbandry support point.
+  - key: agri_support_infra
+    label: Agriculture Support Infrastructure Access
+    class_l1_domain: agriculture
+    rollup: direct
+    explanation: Distance to the nearest agriculture support infrastructure point.
+
+l3_classes:
+  - key: school_primary
+    label: Primary School
+    class_l1_domain: education
+    class_l2_filter_group: essential_education
+    description: School offering primary grades (classes 1-5), from UDISE-style school records.
+    source_dataset: school
+    cleaned_file: school_primary.csv
+    source_id_column: school_code
+    configured_subtypes: [Primary, Primary with Upper Primary, Pr. Up Pr. and Secondary Only, Pr. with Up.Pr. Sec. and H.Sec., Pre-Primary Only]
+  - key: school_upper_primary
+    label: Upper Primary School
+    class_l1_domain: education
+    class_l2_filter_group: essential_education
+    description: School offering upper-primary grades (classes 6-8), from UDISE-style school records.
+    source_dataset: school
+    cleaned_file: school_upper_primary.csv
+    source_id_column: school_code
+    configured_subtypes: [Primary with Upper Primary, Upper Primary only, Pr. Up Pr. and Secondary Only, Pr. with Up.Pr. Sec. and H.Sec., Upper Pr. and Secondary, Up. Pr. Secondary and Higher Sec]
+  - key: school_secondary
+    label: Secondary School
+    class_l1_domain: education
+    class_l2_filter_group: essential_education
+    description: School offering secondary grades (classes 9-10), from UDISE-style school records.
+    source_dataset: school
+    cleaned_file: school_secondary.csv
+    source_id_column: school_code
+    configured_subtypes: [Pr. Up Pr. and Secondary Only, Pr. with Up.Pr. Sec. and H.Sec., Upper Pr. and Secondary, Up. Pr. Secondary and Higher Sec, Secondary Only, Secondary with Higher Secondary]
+  - key: school_higher_secondary
+    label: Higher Secondary School
+    class_l1_domain: education
+    class_l2_filter_group: higher_education
+    description: School or junior college offering higher-secondary grades (classes 11-12).
+    source_dataset: school
+    cleaned_file: school_higher_secondary.csv
+    source_id_column: school_code
+    configured_subtypes: [Pr. with Up.Pr. Sec. and H.Sec., Up. Pr. Secondary and Higher Sec, Secondary with Higher Secondary, Higher Secondary only/Jr. College]
+  - key: college
+    label: College
+    class_l1_domain: education
+    class_l2_filter_group: higher_education
+    description: Degree college from AISHE records, including affiliated, constituent, autonomous, and PG-centre colleges.
+    source_dataset: college
+    cleaned_file: college.csv
+    source_id_column: college_aishe_uid
+    configured_subtypes: [Affiliated College, Constituent / University College, Recognized Center, PG Center / Off-Campus Center, Autonomous College]
+  - key: universities
+    label: University-Type Institution
+    class_l1_domain: education
+    class_l2_filter_group: higher_education
+    description: University-type or standalone institution from AISHE records, such as technical, nursing, teacher-training, and paramedical institutes.
+    source_dataset: universities
+    cleaned_file: universities.csv
+    source_id_column: uni_aishe_code
+    configured_subtypes: [Technical/Polytechnic, Nursing, Teacher Training, Paramedical, PGDM Institutes, Institutes under Ministries, Hotel Management and Catering]
+  - key: health_sub_cen
+    label: Health Sub-Centre
+    class_l1_domain: health
+    class_l2_filter_group: essential_health
+    description: Health sub-centre, the first contact point between the community and the public health system.
+    source_dataset: health_center
+    cleaned_file: health_sub_cen.csv
+    source_id_column: sub_cen_uid
+  - key: health_phc
+    label: Primary Health Centre
+    class_l1_domain: health
+    class_l2_filter_group: essential_health
+    description: Primary Health Centre, the first point of curative care staffed with a medical officer.
+    source_dataset: health_center
+    cleaned_file: health_phc.csv
+    source_id_column: phc_uid
+  - key: health_chc
+    label: Community Health Centre
+    class_l1_domain: health
+    class_l2_filter_group: advanced_health
+    description: Community Health Centre, a block-level referral unit with specialist services.
+    source_dataset: health_center
+    cleaned_file: health_chc.csv
+    source_id_column: chc_uid
+  - key: health_dis_h
+    label: District Hospital
+    class_l1_domain: health
+    class_l2_filter_group: advanced_health
+    description: District hospital, the main secondary-care referral facility of a district.
+    source_dataset: health_center
+    cleaned_file: health_dis_h.csv
+    source_id_column: dis_h_uid
+  - key: health_s_t_h
+    label: Specialist Or Tertiary Hospital
+    class_l1_domain: health
+    class_l2_filter_group: advanced_health
+    description: Specialist or tertiary/teaching hospital offering advanced medical care.
+    source_dataset: health_center
+    cleaned_file: health_s_t_h.csv
+    source_id_column: s_t_h_uid
+  - key: pds
+    label: Public Distribution System
+    class_l1_domain: food_security
+    class_l2_filter_group: essential_services
+    description: Fair price shop under the Public Distribution System supplying subsidised food grains.
+    source_dataset: pds
+    cleaned_file: pds.csv
+    source_id_column: fps_uid
+  - key: csc
+    label: Common Service Centre
+    class_l1_domain: finance
+    class_l2_filter_group: financial_inclusion
+    description: Common Service Centre providing assisted digital access to government and financial services.
+    source_dataset: csc
+    cleaned_file: csc.csv
+    source_id_column: csc_uid
+  - key: bank_mitra
+    label: Bank Mitra
+    class_l1_domain: finance
+    class_l2_filter_group: financial_inclusion
+    description: Bank mitra / business correspondent point offering doorstep banking services.
+    source_dataset: bank_mitra
+    cleaned_file: bank_mitra.csv
+    source_id_column: bank_mitra_uid
+  - key: bank_branch
+    label: Bank Branch
+    class_l1_domain: finance
+    class_l2_filter_group: financial_inclusion
+    description: Scheduled bank branch.
+    source_dataset: bank_branch
+    cleaned_file: bank_branch.csv
+    source_id_column: bank_uid
+  - key: bank_atm
+    label: Bank ATM
+    class_l1_domain: finance
+    class_l2_filter_group: financial_inclusion
+    description: Bank ATM.
+    source_dataset: bank_atm
+    cleaned_file: bank_atm.csv
+    source_id_column: bank_atm_uid
+  - key: apmc
+    label: APMC
+    class_l1_domain: agriculture
+    class_l2_filter_group: apmc_access
+    description: Agricultural Produce Market Committee mandi or regulated market yard.
+    source_dataset: apmc
+    cleaned_file: apmc.csv
+    source_id_column: gid
+    configured_subtypes: [Primary Market Yard, Sub Market Yard, Other, Regulated Primary Market, Regulated Sub Market, Farmers Consumer Market, Non-Regulated Market]
+  - key: agri_industry_markets_trading
+    label: Agriculture Markets And Trading
+    class_l1_domain: agriculture
+    class_l2_filter_group: apmc_access
+    description: Agri-industry unit engaged in markets and trading of agricultural produce.
+    source_dataset: agri_industry
+    cleaned_file: agri_industry_markets_trading.csv
+    source_id_column: agri_industry_id
+  - key: agri_industry_storage_warehousing
+    label: Storage And Warehousing
+    class_l1_domain: agriculture
+    class_l2_filter_group: post_harvest
+    description: Storage and warehousing unit such as godowns, warehouses, and cold storage.
+    source_dataset: agri_industry
+    cleaned_file: agri_industry_storage_warehousing.csv
+    source_id_column: agri_industry_id
+  - key: agri_industry_distribution_utilities
+    label: Distribution Utilities
+    class_l1_domain: agriculture
+    class_l2_filter_group: post_harvest
+    description: Distribution and utility infrastructure supporting agricultural supply chains.
+    source_dataset: agri_industry
+    cleaned_file: agri_industry_distribution_utilities.csv
+    source_id_column: agri_industry_id
+  - key: agri_industry_agri_processing
+    label: Agriculture Processing
+    class_l1_domain: agriculture
+    class_l2_filter_group: post_harvest
+    description: Agriculture processing unit such as mills and produce processing plants.
+    source_dataset: agri_industry
+    cleaned_file: agri_industry_agri_processing.csv
+    source_id_column: agri_industry_id
+  - key: agri_industry_industrial_manufacturing
+    label: Industrial Manufacturing
+    class_l1_domain: agriculture
+    class_l2_filter_group: post_harvest
+    description: Industrial or manufacturing unit relevant to the rural farm economy.
+    source_dataset: agri_industry
+    cleaned_file: agri_industry_industrial_manufacturing.csv
+    source_id_column: agri_industry_id
+  - key: agri_industry_co_operatives_societies
+    label: Cooperatives And Societies
+    class_l1_domain: agriculture
+    class_l2_filter_group: cooperative
+    description: Co-operative or society unit such as PACS and co-operative marketing or processing bodies.
+    source_dataset: agri_industry
+    cleaned_file: agri_industry_co_operatives_societies.csv
+    source_id_column: agri_industry_id
+  - key: agri_industry_dairy_animal_husbandry
+    label: Dairy And Animal Husbandry
+    class_l1_domain: agriculture
+    class_l2_filter_group: livestock
+    description: Dairy and animal husbandry support unit such as dairies, milk chilling centres, and veterinary-linked units.
+    source_dataset: agri_industry
+    cleaned_file: agri_industry_dairy_animal_husbandry.csv
+    source_id_column: agri_industry_id
+  - key: agri_industry_agri_support_infrastructure
+    label: Agriculture Support Infrastructure
+    class_l1_domain: agriculture
+    class_l2_filter_group: agri_support_infra
+    description: Agriculture support infrastructure such as custom hiring centres and farm input or machinery support.
+    source_dataset: agri_industry
+    cleaned_file: agri_industry_agri_support_infrastructure.csv
+    source_id_column: agri_industry_id

--- a/computing/misc/facilities/pipeline.py
+++ b/computing/misc/facilities/pipeline.py
@@ -1,0 +1,1160 @@
+"""Facilities inventory and live proximity pipeline from local GeoPackages."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Mapping
+
+import geopandas as gpd
+import pandas as pd
+from django.conf import settings
+from scipy.spatial import cKDTree
+
+from utilities.pipelines import AdminScope, CSAdminSource, StandardRequest, load_config
+from utilities.pipelines.admin import (
+    ADMIN_COLUMN_DESCRIPTIONS,
+    admin_output_frame,
+    admin_presentation_frame,
+)
+from utilities.pipelines.schema import (
+    STATUS_COMPUTED,
+    STATUS_NO_DATA,
+    STATUS_NO_VILLAGE_ID,
+    OutputOptions,
+    resolve_output_options,
+    status_column_config,
+)
+from utilities.pipelines.gpkg import (
+    IndexSpec,
+    column_expression,
+    connect_gpkg,
+    ensure_indexes,
+    quote_identifier,
+    read_table,
+)
+from utilities.pipelines.outputs import (
+    OutputBundle,
+    column_dictionary,
+    frame_profile,
+    input_signatures,
+    mark_cached_result,
+    scope_output_identity,
+    slug,
+    stable_hash,
+    utc_now_text,
+)
+from utilities.pipelines.publish import (
+    publish_gpkg_layer,
+    publish_gpkg_layers,
+    register_layer,
+)
+from utilities.pipelines.unicode import normalize_unicode_frame
+from nrm_app.celery import app
+from utilities.constants import FACILITIES_GEOSERVER_WORKSPACE
+
+
+CONFIG_PATH = Path(__file__).with_name("facilities_pipeline.yaml")
+ALGORITHM = "local-facilities-live-proximity"
+ALGORITHM_VERSION = "2.0"
+
+
+def _repo_path(path: str | Path) -> Path:
+    path = Path(path)
+    if path.is_absolute():
+        return path
+    base_dir = Path(settings.BASE_DIR) if settings.configured else Path.cwd()
+    return base_dir / path
+
+
+def _layer_name(prefix: str, district: str | None, tehsil: str | None) -> str:
+    return f"{prefix}_{slug(district)}_{slug(tehsil)}".strip("_")
+
+
+def _cli_request(state: str, district: str, tehsil: str, sync_to_geoserver: bool = True) -> StandardRequest:
+    return StandardRequest.from_mapping(
+        {
+            "scope": {
+                "level": "tehsil",
+                "state_name": state,
+                "district_name": district,
+                "tehsil_name": tehsil,
+            },
+            "publish": {"sync_to_geoserver": sync_to_geoserver, "overwrite": True},
+            "outputs": {"geoserver": sync_to_geoserver},
+        }
+    )
+
+
+def _ensure_facility_indexes(config: Mapping[str, Any]) -> list[str]:
+    table = config["sources"]["facilities_layer"]
+    specs = (
+        IndexSpec(
+            name=f"idx_{table}_class_l3_lat_lon",
+            table=table,
+            expressions=(
+                column_expression("class_l3_facility_class"),
+                column_expression("latitude"),
+                column_expression("longitude"),
+            ),
+        ),
+    )
+    return ensure_indexes(_repo_path(config["sources"]["facilities_gpkg"]), specs)
+
+
+def _taxonomy(config: Mapping[str, Any]) -> pd.DataFrame:
+    classification_path = config.get("sources", {}).get("classification_yaml")
+    if classification_path:
+        classification = load_config(_repo_path(classification_path))
+        rows: list[dict[str, Any]] = []
+        l2_rollups = {
+            item["key"]: item.get("rollup", "direct")
+            for item in classification.get("l2_groups", [])
+        }
+        for sort_order, item in enumerate(classification.get("l3_classes", [])):
+            rows.append(
+                {
+                    "class_l1_domain": item.get("class_l1_domain"),
+                    "class_l2_filter_group": item.get("class_l2_filter_group"),
+                    "class_l3_facility_class": item.get("key"),
+                    "class_l3_label": item.get("label"),
+                    "configured_subtypes": ";".join(item.get("configured_subtypes", []) or []),
+                    "filter_logic": l2_rollups.get(item.get("class_l2_filter_group"), "direct"),
+                    "sort_order": sort_order,
+                }
+            )
+        taxonomy = pd.DataFrame(rows)
+        if not taxonomy.empty:
+            return taxonomy
+
+    taxonomy = read_table(
+        _repo_path(config["sources"]["facilities_gpkg"]),
+        config["sources"]["taxonomy_table"],
+    )
+    if "sort_order" in taxonomy.columns:
+        taxonomy = taxonomy.sort_values("sort_order")
+    return taxonomy
+
+
+def _classification(config: Mapping[str, Any]) -> dict[str, Any]:
+    path = config.get("sources", {}).get("classification_yaml")
+    if path:
+        return load_config(_repo_path(path))
+    taxonomy = _taxonomy(config)
+    l2_groups: list[dict[str, Any]] = []
+    for group, rows in taxonomy.groupby("class_l2_filter_group", sort=False):
+        logic_values = [value for value in rows.get("filter_logic", pd.Series(dtype=str)).dropna().astype(str).unique() if value]
+        l2_groups.append(
+            {
+                "key": group,
+                "label": str(group).replace("_", " ").title(),
+                "rollup": logic_values[0] if logic_values else "direct",
+                "class_l1_domain": rows["class_l1_domain"].dropna().iloc[0] if "class_l1_domain" in rows and not rows["class_l1_domain"].dropna().empty else None,
+            }
+        )
+    return {
+        "access_rollup_notes": {},
+        "l2_groups": l2_groups,
+        "l3_classes": [
+            {
+                "key": row.class_l3_facility_class,
+                "label": str(row.class_l3_facility_class).replace("_", " ").title(),
+                "class_l1_domain": getattr(row, "class_l1_domain", None),
+                "class_l2_filter_group": getattr(row, "class_l2_filter_group", None),
+            }
+            for row in taxonomy.itertuples(index=False)
+        ],
+    }
+
+
+def _bbox(admin_rows) -> tuple[float, float, float, float]:
+    minx, miny, maxx, maxy = admin_rows.total_bounds
+    return float(minx), float(miny), float(maxx), float(maxy)
+
+
+def _read_facilities_bbox(
+    config: Mapping[str, Any],
+    bbox: tuple[float, float, float, float],
+    *,
+    class_l3_values: list[str] | None = None,
+    expansion_degrees: float = 0,
+) -> gpd.GeoDataFrame:
+    minx, miny, maxx, maxy = bbox
+    minx -= expansion_degrees
+    miny -= expansion_degrees
+    maxx += expansion_degrees
+    maxy += expansion_degrees
+    path = _repo_path(config["sources"]["facilities_gpkg"])
+    table = config["sources"]["facilities_layer"]
+    columns = ["fid", *config["facility_columns"]]
+    select_columns = ", ".join(f"f.{quote_identifier(col)}" for col in columns)
+    if class_l3_values:
+        placeholders = ", ".join(["?"] * len(class_l3_values))
+        params: list[Any] = [*class_l3_values, minx, maxx, miny, maxy]
+        sql = f"""
+            SELECT {select_columns}
+            FROM {quote_identifier(table)} f
+            WHERE f.class_l3_facility_class IN ({placeholders})
+              AND f.longitude BETWEEN ? AND ?
+              AND f.latitude BETWEEN ? AND ?
+              AND f.latitude IS NOT NULL
+              AND f.longitude IS NOT NULL
+        """
+    else:
+        params = [minx, maxx, miny, maxy]
+        sql = f"""
+            SELECT {select_columns}
+            FROM {quote_identifier(table)} f
+            JOIN rtree_facilities_geom r ON r.id = f.fid
+            WHERE r.maxx >= ?
+              AND r.minx <= ?
+              AND r.maxy >= ?
+              AND r.miny <= ?
+              AND f.latitude IS NOT NULL
+              AND f.longitude IS NOT NULL
+        """
+    with connect_gpkg(path, read_only=True) as connection:
+        frame = pd.read_sql_query(sql, connection, params=params)
+    if frame.empty:
+        return gpd.GeoDataFrame(frame, geometry=[], crs="EPSG:4326")
+    geometry = gpd.points_from_xy(frame["longitude"], frame["latitude"], crs="EPSG:4326")
+    return gpd.GeoDataFrame(frame, geometry=geometry)
+
+
+def _inventory(candidates: gpd.GeoDataFrame, admin_rows) -> gpd.GeoDataFrame:
+    if candidates.empty:
+        return candidates
+    admin_context = admin_rows[["fid", "pc11_village_id", "village_id", "NAME", "state_name", "district_name", "TEHSIL", "geometry"]].copy()
+    admin_context["_admin_key"] = admin_context["fid"]
+    joined = gpd.sjoin(candidates, admin_context, how="inner", predicate="intersects")
+    if "index_right" in joined.columns:
+        joined = joined.drop(columns=["index_right"])
+    joined["inside_requested_scope"] = True
+    joined["facilities_layer_kind"] = "inventory"
+    joined["title"] = joined["facility_name"].fillna(joined["facility_uid"])
+    return joined.drop_duplicates(subset=["facility_uid", "_admin_key"])
+
+
+def _village_points(admin_rows) -> pd.DataFrame:
+    rows = admin_rows.copy()
+    points = rows.geometry.representative_point()
+    frame = pd.DataFrame(rows.drop(columns=["geometry"]))
+    frame["_admin_key"] = frame["fid"]
+    frame["_village_lon"] = points.x
+    frame["_village_lat"] = points.y
+    return frame
+
+
+def _haversine_km(lat1, lon1, lat2, lon2, radius_km: float) -> float:
+    lat1 = math.radians(float(lat1))
+    lon1 = math.radians(float(lon1))
+    lat2 = math.radians(float(lat2))
+    lon2 = math.radians(float(lon2))
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    a = math.sin(dlat / 2) ** 2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
+    return 2 * radius_km * math.asin(math.sqrt(a))
+
+
+def _candidate_pool(
+    config: Mapping[str, Any],
+    bbox: tuple[float, float, float, float],
+    taxonomy: pd.DataFrame,
+) -> tuple[gpd.GeoDataFrame, dict[str, Any]]:
+    search = config["search"]
+    base = _read_facilities_bbox(config, bbox, expansion_degrees=float(search["base_expansion_degrees"]))
+    required = taxonomy["class_l3_facility_class"].dropna().astype(str).tolist()
+    covered = set(base["class_l3_facility_class"].dropna().astype(str)) if not base.empty else set()
+    missing = [value for value in required if value not in covered]
+    supplemental = gpd.GeoDataFrame(pd.DataFrame(), geometry=[], crs="EPSG:4326")
+    if missing:
+        supplemental = _read_facilities_bbox(
+            config,
+            bbox,
+            class_l3_values=missing,
+            expansion_degrees=float(search["supplemental_expansion_degrees"]),
+        )
+    frames = [frame.dropna(axis=1, how="all") for frame in (base, supplemental) if not frame.empty]
+    pool = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+    if pool.empty:
+        pool = gpd.GeoDataFrame(pool, geometry=[], crs="EPSG:4326")
+    else:
+        pool = gpd.GeoDataFrame(pool, geometry="geometry", crs="EPSG:4326").drop_duplicates(subset=["facility_uid"])
+    metadata = {
+        "base_candidates": int(len(base)),
+        "supplemental_candidates": int(len(supplemental)),
+        "candidate_pool": int(len(pool)),
+        "missing_after_supplemental": sorted(set(required) - set(pool["class_l3_facility_class"].dropna().astype(str))) if not pool.empty else required,
+    }
+    return pool, metadata
+
+
+def _nearest(
+    pool: gpd.GeoDataFrame,
+    village_points: pd.DataFrame,
+    taxonomy: pd.DataFrame,
+    classification: Mapping[str, Any],
+    inside_facility_ids: set[Any],
+    radius_km: float,
+) -> tuple[gpd.GeoDataFrame, pd.DataFrame]:
+    if pool.empty or village_points.empty:
+        return gpd.GeoDataFrame(pd.DataFrame(), geometry=[], crs="EPSG:4326"), pd.DataFrame()
+    nearest_rows: list[dict[str, Any]] = []
+    point_xy = village_points[["_village_lon", "_village_lat"]].to_numpy()
+    for tax in taxonomy.itertuples(index=False):
+        class_l3 = str(tax.class_l3_facility_class)
+        candidates = pool[pool["class_l3_facility_class"] == class_l3].reset_index(drop=True)
+        if candidates.empty:
+            continue
+        tree = cKDTree(candidates[["longitude", "latitude"]].to_numpy())
+        distances, indexes = tree.query(point_xy, k=1)
+        for village_idx, candidate_idx in enumerate(indexes):
+            village = village_points.iloc[village_idx]
+            facility = candidates.iloc[int(candidate_idx)]
+            distance_km = _haversine_km(
+                village["_village_lat"],
+                village["_village_lon"],
+                facility["latitude"],
+                facility["longitude"],
+                radius_km,
+            )
+            row = {
+                "_admin_key": village.get("_admin_key"),
+                "fid": village.get("fid"),
+                "pc11_village_id": village.get("pc11_village_id"),
+                "village_id": village.get("village_id"),
+                "village_name": village.get("NAME"),
+                "state_name": village.get("state_name"),
+                "district_name": village.get("district_name"),
+                "TEHSIL": village.get("TEHSIL"),
+                "service_level": "l3",
+                "class_l1_domain": getattr(tax, "class_l1_domain"),
+                "class_l2_filter_group": getattr(tax, "class_l2_filter_group"),
+                "class_l3_facility_class": class_l3,
+                "class_l3_label": getattr(tax, "class_l3_label", class_l3.replace("_", " ").title()),
+                "nearest_distance_km": round(distance_km, 6),
+                "inside_requested_scope": bool(facility["facility_uid"] in inside_facility_ids),
+                "facilities_layer_kind": "nearest",
+                "title": facility.get("facility_name") or facility.get("facility_uid"),
+            }
+            for column in [
+                "facility_uid",
+                "facility_name",
+                "facility_code",
+                "latitude",
+                "longitude",
+                "class_l4_facility_subtype",
+                "urban_rural",
+                "pincode",
+                "village_census11",
+            ]:
+                row[column] = facility.get(column)
+            row["geometry"] = facility.geometry
+            nearest_rows.append(row)
+    nearest = gpd.GeoDataFrame(nearest_rows, geometry="geometry", crs="EPSG:4326")
+    village_service = _village_service(village_points, nearest, classification)
+    return nearest, village_service
+
+
+def _village_service(village_points: pd.DataFrame, nearest: pd.DataFrame, classification: Mapping[str, Any]) -> pd.DataFrame:
+    base = village_points.drop(columns=["_village_lon", "_village_lat"]).copy()
+    if nearest.empty:
+        return base
+    l3 = nearest.copy()
+    l3["_slug"] = l3["class_l3_facility_class"].map(slug)
+    for metric, suffix in (
+        ("nearest_distance_km", "distance_km"),
+        ("facility_uid", "facility_uid"),
+        ("inside_requested_scope", "inside_scope"),
+    ):
+        pivot = l3.pivot_table(index="_admin_key", columns="_slug", values=metric, aggfunc="first")
+        pivot.columns = [f"l3_{col}_{suffix}" for col in pivot.columns]
+        base = base.merge(pivot.reset_index(), on="_admin_key", how="left")
+    l2_rollups = {
+        item["key"]: str(item.get("rollup") or "direct").lower()
+        for item in classification.get("l2_groups", [])
+    }
+    selected_l2_rows: list[pd.Series] = []
+    for _, group in l3.groupby(["_admin_key", "class_l2_filter_group"], dropna=False):
+        distances = pd.to_numeric(group["nearest_distance_km"], errors="coerce")
+        if distances.dropna().empty:
+            continue
+        rollup = l2_rollups.get(str(group["class_l2_filter_group"].iloc[0]), "direct")
+        selected_index = distances.idxmax() if rollup == "max" else distances.idxmin()
+        selected_l2_rows.append(l3.loc[selected_index])
+    l2 = pd.DataFrame(selected_l2_rows)
+    if l2.empty:
+        base["facilities_layer_kind"] = "village_service"
+        base["title"] = base["NAME"].fillna(base["fid"])
+        return base
+    l2["_slug"] = l2["class_l2_filter_group"].map(slug)
+    for metric, suffix in (
+        ("nearest_distance_km", "distance_km"),
+        ("facility_uid", "facility_uid"),
+        ("class_l3_facility_class", "selected_l3"),
+        ("class_l3_label", "selected_l3_label"),
+    ):
+        pivot = l2.pivot_table(index="_admin_key", columns="_slug", values=metric, aggfunc="first")
+        pivot.columns = [f"l2_{col}_{suffix}" for col in pivot.columns]
+        base = base.merge(pivot.reset_index(), on="_admin_key", how="left")
+    base["facilities_layer_kind"] = "village_service"
+    base["title"] = base["NAME"].fillna(base["fid"])
+    return base
+
+
+def _useful_value(value: Any) -> str | None:
+    if value is None or value != value:
+        return None
+    text = str(value).strip()
+    if not text or text.lower() in {"nan", "none", "null", "0.0"}:
+        return None
+    return text
+
+
+def _clean_facility_text(value: Any) -> str | None:
+    """Clean compact labels for report-facing nearest-facility cells."""
+
+    text = _useful_value(value)
+    if not text:
+        return None
+    text = re.sub(r"(?<=[A-Za-z])[.,](?=[A-Za-z])", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text or None
+
+
+def _facility_detail(row: pd.Series | None) -> str | None:
+    """Build a compact human-readable facility detail for report CSVs."""
+
+    if row is None:
+        return None
+    parts: list[str] = []
+    for column in ("facility_name", "class_l4_facility_subtype", "class_l3_label", "facility_code"):
+        value = _clean_facility_text(row.get(column)) if column != "facility_code" else _useful_value(row.get(column))
+        if value:
+            parts.append(value if column != "facility_code" else f"code {value}")
+    scope_value = row.get("inside_requested_scope")
+    if scope_value is not None and scope_value == scope_value:
+        parts.append("inside scope" if bool(scope_value) else "outside scope")
+    return " | ".join(dict.fromkeys(parts)) or None
+
+
+def _output_contract(config: Mapping[str, Any]) -> Mapping[str, Any]:
+    return config.get("output_contract", {})
+
+
+def _l2_output_column(group: Mapping[str, Any], config: Mapping[str, Any]) -> str:
+    key = str(group["key"])
+    configured = _output_contract(config).get("l2_distance_columns", {})
+    if key in configured:
+        return str(configured[key])
+    return f"{slug(key)}_cat_distance_km"
+
+
+def _l3_classes_by_group(classification: Mapping[str, Any]) -> dict[str, list[Mapping[str, Any]]]:
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for item in classification.get("l3_classes", []):
+        grouped.setdefault(item["class_l2_filter_group"], []).append(item)
+    return grouped
+
+
+def _service_output_columns(classification: Mapping[str, Any], config: Mapping[str, Any]) -> list[str]:
+    """Report columns derived from the classification structure: for each L2
+    group the category distance column, then the nearest-facility detail and
+    distance pair for each of its L3 classes."""
+
+    l3_by_l2 = _l3_classes_by_group(classification)
+    columns: list[str] = []
+    for group in classification.get("l2_groups", []):
+        columns.append(_l2_output_column(group, config))
+        for item in l3_by_l2.get(group["key"], []):
+            l3_slug = slug(item["key"])
+            columns.append(f"nearest_{l3_slug}")
+            columns.append(f"nearest_{l3_slug}_distance_km")
+    return columns
+
+
+def _machine_output_columns(classification: Mapping[str, Any]) -> list[str]:
+    """GeoPackage value columns in classification order.
+
+    The `l2_*`/`l3_*` columns are produced by pivot tables, which sort their
+    columns alphabetically. Ordering them here keeps the GeoPackage (and the
+    GeoServer feature type built from it) in the same group-then-member order
+    as the documented classification contract.
+    """
+
+    l3_by_l2 = _l3_classes_by_group(classification)
+    columns: list[str] = []
+    for group in classification.get("l2_groups", []):
+        group_slug = slug(group["key"])
+        columns.extend(
+            [
+                f"l2_{group_slug}_distance_km",
+                f"l2_{group_slug}_selected_l3",
+                f"l2_{group_slug}_selected_l3_label",
+                f"l2_{group_slug}_facility_uid",
+            ]
+        )
+        for item in l3_by_l2.get(group["key"], []):
+            l3_slug = slug(item["key"])
+            columns.extend(
+                [
+                    f"l3_{l3_slug}_distance_km",
+                    f"l3_{l3_slug}_facility_uid",
+                    f"l3_{l3_slug}_inside_scope",
+                ]
+            )
+    return columns
+
+
+def _column_descriptions(classification: Mapping[str, Any], config: Mapping[str, Any]) -> dict[str, str]:
+    """Human-readable descriptions for report columns, driven by the
+    classification YAML description templates."""
+
+    templates = classification.get("output_column_descriptions", {})
+    category_templates = templates.get("category_distance", {})
+    descriptions = dict(ADMIN_COLUMN_DESCRIPTIONS)
+    status_name, _ = status_column_config(config)
+    if status_name and templates.get("status"):
+        descriptions[status_name] = str(templates["status"])
+    l3_by_l2 = _l3_classes_by_group(classification)
+    for group in classification.get("l2_groups", []):
+        rollup = str(group.get("rollup") or "direct").lower()
+        label = str(group.get("label") or group["key"])
+        template = category_templates.get(rollup)
+        if template:
+            descriptions[_l2_output_column(group, config)] = str(template).format(label=label)
+        for item in l3_by_l2.get(group["key"], []):
+            l3_label = str(item.get("label") or item["key"])
+            l3_slug = slug(item["key"])
+            if templates.get("nearest_facility"):
+                descriptions[f"nearest_{l3_slug}"] = str(templates["nearest_facility"]).format(label=l3_label)
+            if templates.get("nearest_distance"):
+                descriptions[f"nearest_{l3_slug}_distance_km"] = str(templates["nearest_distance"]).format(label=l3_label)
+    return descriptions
+
+
+def _machine_column_describer(classification: Mapping[str, Any], config: Mapping[str, Any]):
+    """Describe both report columns and the verbose `l2_*`/`l3_*` GPKG columns."""
+
+    descriptions = _column_descriptions(classification, config)
+    labels = {slug(item["key"]): str(item.get("label") or item["key"]) for item in classification.get("l3_classes", [])}
+    labels.update({slug(group["key"]): str(group.get("label") or group["key"]) for group in classification.get("l2_groups", [])})
+    patterns = (
+        ("l2_", "_selected_l3_label", "Label of the L3 facility class selected for the {label} group."),
+        ("l2_", "_selected_l3", "L3 facility class selected for the {label} group."),
+        ("l2_", "_distance_km", "Access distance in km for the {label} group."),
+        ("l2_", "_facility_uid", "Identifier of the facility selected for the {label} group."),
+        ("l3_", "_distance_km", "Distance in km to the nearest {label}."),
+        ("l3_", "_facility_uid", "Identifier of the nearest {label}."),
+        ("l3_", "_inside_scope", "Whether the nearest {label} lies inside the requested boundary."),
+    )
+
+    def describe(name: str) -> str | None:
+        if name in descriptions:
+            return descriptions[name]
+        if name == "facilities_layer_kind":
+            return "Facilities output role for this feature."
+        if name == "title":
+            return "Human-readable feature title used by map viewers."
+        for prefix, suffix, template in patterns:
+            if name.startswith(prefix) and name.endswith(suffix):
+                stem = name[len(prefix) : -len(suffix)]
+                if stem in labels:
+                    return template.format(label=labels[stem])
+        return None
+
+    return describe
+
+
+def _machine_column_renamer(classification: Mapping[str, Any], config: Mapping[str, Any]):
+    """Return optional report-facing names without changing stored fields."""
+
+    l2_targets: dict[str, str] = {}
+    for group in classification.get("l2_groups", []):
+        group_slug = slug(group["key"])
+        l2_targets[f"l2_{group_slug}_distance_km"] = _l2_output_column(group, config)
+        l2_targets[f"l2_{group_slug}_facility_uid"] = f"{group_slug}_selected_facility_uid"
+        l2_targets[f"l2_{group_slug}_selected_l3"] = f"{group_slug}_selected_facility_class"
+        l2_targets[f"l2_{group_slug}_selected_l3_label"] = f"{group_slug}_selected_facility_label"
+
+    def rename(name: str) -> str | None:
+        if name in l2_targets:
+            return l2_targets[name]
+        match = re.fullmatch(r"l3_(.+)_(distance_km|facility_uid|inside_scope)", name)
+        if not match:
+            return None
+        facility, suffix = match.groups()
+        return f"nearest_{facility}_{suffix}"
+
+    return rename
+
+
+def _facility_point_outputs(
+    inventory: gpd.GeoDataFrame,
+    nearest: gpd.GeoDataFrame,
+) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]:
+    """Return the two clean point layers in the facilities collection."""
+
+    inventory_output = inventory.drop(
+        columns=["_admin_key", "index_right"], errors="ignore"
+    ).rename(
+        columns={
+            "fid_left": "facility_source_fid",
+            "fid_right": "admin_source_fid",
+            "NAME": "admin_village_name",
+            "TEHSIL": "tehsil_name",
+        }
+    )
+    nearest_output = nearest.drop(columns=["_admin_key", "fid"], errors="ignore").rename(
+        columns={"TEHSIL": "tehsil_name"}
+    )
+    return (
+        gpd.GeoDataFrame(normalize_unicode_frame(inventory_output), geometry="geometry", crs=inventory.crs),
+        gpd.GeoDataFrame(normalize_unicode_frame(nearest_output), geometry="geometry", crs=nearest.crs),
+    )
+
+
+def _point_column_describer(name: str) -> str | None:
+    descriptions = {
+        **ADMIN_COLUMN_DESCRIPTIONS,
+        "facility_uid": "Stable Core Stack identifier for the facility point.",
+        "facility_name": "Source facility name, normalized as Unicode text.",
+        "facility_code": "Source facility code when available.",
+        "nearest_distance_km": "Great-circle distance from the village locality point to this facility, in kilometres.",
+        "inside_requested_scope": "Whether the facility point lies inside the requested administrative boundary.",
+        "class_l1_domain": "Top-level facility domain.",
+        "class_l2_filter_group": "Facility service group used by proximity rollups.",
+        "class_l3_facility_class": "Standard Core Stack facility class.",
+        "class_l3_label": "Human-readable standard facility class label.",
+        "facilities_layer_kind": "Facilities output role for this feature.",
+        "title": "Human-readable facility title used by map viewers.",
+        "facility_source_fid": "Internal feature identifier from the facilities source GeoPackage.",
+        "admin_source_fid": "Internal feature identifier from the administrative source GeoPackage.",
+        "pc11_village_id": "Population Census 2011 village identifier.",
+        "admin_village_name": "Village name from the administrative boundary source.",
+        "latitude": "Facility latitude in decimal degrees (WGS84).",
+        "longitude": "Facility longitude in decimal degrees (WGS84).",
+        "class_l4_facility_subtype": "Detailed source facility subtype when available.",
+        "urban_rural": "Source urban or rural classification.",
+        "pincode": "Postal PIN code associated with the facility.",
+        "establishment_year": "Year the facility was established when available.",
+        "district_lgd": "Local Government Directory district code from the facility source.",
+        "village_census11": "Census 2011 village code associated with the facility source.",
+        "membership_count": "Source membership count where the facility represents an institution or collective.",
+        "service_level": "Taxonomy level used for the nearest-facility association.",
+    }
+    if re.fullmatch(r"class_k[1-8]", name):
+        return "Normalized auxiliary facility classification field."
+    return descriptions.get(name)
+
+
+def _status_value(village_id: Any, has_candidates: bool) -> str:
+    if pd.isna(village_id):
+        return STATUS_NO_VILLAGE_ID
+    if not has_candidates:
+        return STATUS_NO_DATA
+    return STATUS_COMPUTED
+
+
+def _focused_service_frame(
+    village_service_gdf: gpd.GeoDataFrame,
+    nearest: pd.DataFrame,
+    classification: Mapping[str, Any],
+    config: Mapping[str, Any],
+) -> pd.DataFrame:
+    """Return the human-readable village x service matrix for report CSVs:
+    admin columns, the status column, then the configured service columns."""
+
+    raw_frame = village_service_gdf.drop(columns=["geometry"], errors="ignore")
+    frame = admin_presentation_frame(raw_frame)
+    admin_columns = list(frame.columns)
+    frame["_admin_key"] = raw_frame["_admin_key"].to_numpy()
+    service_rows = raw_frame.set_index("_admin_key", drop=False)
+    status_name, _ = status_column_config(config)
+    nearest_by_village_l3: dict[tuple[Any, str], pd.Series] = {}
+    if not nearest.empty:
+        for _, row in nearest.iterrows():
+            nearest_by_village_l3[(row.get("_admin_key"), row.get("class_l3_facility_class"))] = row
+
+    rows: list[dict[str, Any]] = []
+    l3_by_l2 = _l3_classes_by_group(classification)
+    for _, source in frame.iterrows():
+        row = source.to_dict()
+        admin_key = row.pop("_admin_key", None)
+        service = service_rows.loc[admin_key] if admin_key in service_rows.index else pd.Series(dtype=object)
+        has_village_id = pd.notna(row.get("village_id"))
+        if status_name:
+            row[status_name] = _status_value(row.get("village_id"), not nearest.empty)
+        if not has_village_id or nearest.empty:
+            rows.append(row)
+            continue
+
+        for group in classification.get("l2_groups", []):
+            group_key = group["key"]
+            group_slug = slug(group_key)
+            row[_l2_output_column(group, config)] = service.get(f"l2_{group_slug}_distance_km")
+            for item in l3_by_l2.get(group_key, []):
+                l3_key = item["key"]
+                l3_slug = slug(l3_key)
+                nearest_row = nearest_by_village_l3.get((admin_key, l3_key))
+                row[f"nearest_{l3_slug}"] = _facility_detail(nearest_row)
+                row[f"nearest_{l3_slug}_distance_km"] = None if nearest_row is None else nearest_row.get("nearest_distance_km")
+        rows.append(row)
+    ordered = [*admin_columns]
+    if status_name:
+        ordered.append(status_name)
+    ordered.extend(_service_output_columns(classification, config))
+    return pd.DataFrame(rows).reindex(columns=list(dict.fromkeys(ordered)))
+
+
+def _column_reference_lines(column_entries: list[Mapping[str, Any]]) -> list[str]:
+    lines = [
+        "## Column Reference",
+        "",
+        "| Column | Type | Rename to (optional) | Description |",
+        "| --- | --- | --- | --- |",
+    ]
+    for entry in column_entries:
+        description = str(entry.get("description") or "").replace("|", "\\|").replace("\n", " ")
+        rename_to = entry.get("rename_to") or ""
+        lines.append(f"| `{entry['column']}` | {entry.get('datatype', '')} | {rename_to} | {description} |")
+    lines.append("")
+    return lines
+
+
+def _readme_lines(
+    request: StandardRequest,
+    config: Mapping[str, Any],
+    result_name: str,
+    result: Mapping[str, Any],
+    column_entries: list[Mapping[str, Any]] | None = None,
+) -> list[str]:
+    lines = [
+        f"# {result_name}",
+        "",
+        f"Generated at: `{utc_now_text()}`",
+        "",
+        "## What This Dataset Is For",
+        "",
+        "This dataset helps a village, tehsil, or district understand how far people are from important public services and rural infrastructure. It is designed for Core Stack reports, local planning conversations, and GIS review.",
+        "",
+        "The source facility points were cleaned into the Core Stack pan-India facilities GeoPackage. At runtime, this pipeline selects only the requested geography from `cs_admin_standard.gpkg`, finds nearby facilities from `cs_pan_india_facilities.gpkg`, and writes the result back with village boundaries so the data can be opened directly in GIS or published to GeoServer.",
+        "",
+        "## Request",
+        "",
+        f"- Level: `{request.scope.level}`",
+        f"- State: `{request.scope.state_name}`",
+        f"- District: `{request.scope.district_name}`",
+        f"- Tehsil/block: `{request.scope.tehsil_name}`",
+        "",
+        "## Data Quality",
+        "",
+        f"- Village rows: `{result.get('village_rows')}`",
+        f"- Inventory facilities: `{result.get('inventory_rows')}`",
+        f"- Nearest rows: `{result.get('nearest_rows')}`",
+        f"- Candidate pool rows: `{result.get('candidate_pool')}`",
+        f"- Focused service rows: `{result.get('focused_service_rows')}`",
+        "",
+        "## How To Read The Distance Columns",
+        "",
+        "- `*_cat_distance_km` columns summarize a service category for the village. For essentials bundles (schooling tiers, basic health, financial inclusion) they use the farthest required service, so a low value means the whole baseline bundle is nearby. For opportunity gateways (higher education, advanced health, markets, post-harvest) they use the nearest option, since reaching any one member opens that access. Single-service groups use the nearest point directly.",
+        "- `nearest_<facility>` columns hold a compact facility detail (name, subtype, code, inside/outside the requested boundary); the paired `nearest_<facility>_distance_km` column holds the great-circle distance in km from the village locality point.",
+        "",
+        "## Local GIS Outputs",
+        "",
+        "The village-properties GeoPackage keeps village geometry plus the full machine columns (`l2_*`, `l3_*`). The facility-points GeoPackage contains exactly two layers: the facilities physically inside the tehsil and the village-nearest facility collection used by the distance calculation.",
+        "",
+        "Column descriptions and optional rename mappings are recorded in the run metadata; the GeoPackage is the only local data export.",
+        "",
+    ]
+    if column_entries:
+        lines.extend(_column_reference_lines(column_entries))
+    geoserver = result.get("geoserver") or {}
+    if geoserver.get("wfs_url") or geoserver.get("wms_url"):
+        lines.extend(
+            [
+                "## GeoServer Layer",
+                "",
+                f"- WFS GeoJSON: {geoserver.get('wfs_url')}",
+                f"- WMS layer: {geoserver.get('wms_url')}",
+                "",
+            ]
+        )
+    lines.extend(["## Cautions", ""])
+    lines.extend([f"- {item}" for item in config.get("readme", {}).get("cautions", [])])
+    return lines
+
+
+def _cache_input_signatures(config: Mapping[str, Any], config_path: str | Path) -> dict[str, dict[str, Any]]:
+    sources = config.get("sources", {})
+    paths: dict[str, str | Path] = {
+        "pipeline_config": _repo_path(config_path),
+        "admin_gpkg": _repo_path(sources["admin_gpkg"]),
+        "facilities_gpkg": _repo_path(sources["facilities_gpkg"]),
+    }
+    if sources.get("classification_yaml"):
+        paths["classification_yaml"] = _repo_path(sources["classification_yaml"])
+    return input_signatures(paths)
+
+
+def _cache_key(request: StandardRequest, outputs: OutputOptions) -> str:
+    publish_options = asdict(request.publish)
+    publish_options.pop("use_pregenerated", None)
+    return stable_hash(
+        {
+            "algorithm": ALGORITHM,
+            "algorithm_version": ALGORITHM_VERSION,
+            "scope": asdict(request.scope),
+            "outputs": asdict(outputs),
+            "publish": publish_options,
+        }
+    )
+
+
+def _required_result_paths(outputs: OutputOptions, request: StandardRequest) -> tuple[str, ...]:
+    required: list[str] = ["links_path"]
+    if outputs.metadata:
+        required.append("run_metadata_path")
+    if outputs.gpkg or (request.publish.sync_to_geoserver and outputs.geoserver):
+        required.extend(("gpkg_path", "facility_points_gpkg_path"))
+    if outputs.readme:
+        required.append("readme_path")
+    return tuple(dict.fromkeys(required))
+
+
+def run_facilities_pipeline(
+    request: StandardRequest,
+    *,
+    config_path: str | Path = CONFIG_PATH,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    timings: dict[str, float] = {}
+    config = load_config(config_path)
+    outputs = resolve_output_options(request, config)
+    output_config = config["output"]
+    output_parts, layer_name = scope_output_identity(output_config["layer_prefix"], request.scope)
+    output_root = _repo_path(output_config["root"]).joinpath(*output_parts)
+    bundle = OutputBundle(output_root, layer_name)
+    cache_key = _cache_key(request, outputs)
+    cache_signatures = _cache_input_signatures(config, config_path)
+    required_result_paths = _required_result_paths(outputs, request)
+    if request.publish.use_pregenerated:
+        cached = bundle.cached_result(
+            cache_key=cache_key,
+            signatures=cache_signatures,
+            required_result_paths=required_result_paths,
+        )
+        if cached:
+            return mark_cached_result(cached, started)
+
+    t0 = time.perf_counter()
+    created_facility_indexes = _ensure_facility_indexes(config)
+    timings["ensure_facility_indexes_seconds"] = round(time.perf_counter() - t0, 3)
+
+    t0 = time.perf_counter()
+    admin_source = CSAdminSource(_repo_path(config["sources"]["admin_gpkg"]), table_name=config["sources"]["admin_layer"])
+    admin_selection = admin_source.read_scope(AdminScope.from_mapping(asdict(request.scope)), include_geometry=True)
+    admin_rows = admin_selection.rows
+    bounds = _bbox(admin_rows)
+    village_points = _village_points(admin_rows)
+    timings["read_admin_seconds"] = round(time.perf_counter() - t0, 3)
+
+    t0 = time.perf_counter()
+    classification = _classification(config)
+    taxonomy = _taxonomy(config)
+    inventory_candidates = _read_facilities_bbox(config, bounds, expansion_degrees=0)
+    inventory = _inventory(inventory_candidates, admin_rows)
+    timings["read_inventory_seconds"] = round(time.perf_counter() - t0, 3)
+
+    t0 = time.perf_counter()
+    pool, pool_metadata = _candidate_pool(config, bounds, taxonomy)
+    nearest, village_service = _nearest(
+        pool,
+        village_points,
+        taxonomy,
+        classification,
+        set(inventory["facility_uid"]) if not inventory.empty else set(),
+        float(config["search"]["earth_radius_km"]),
+    )
+    timings["build_nearest_seconds"] = round(time.perf_counter() - t0, 3)
+
+    village_service_values = village_service.drop(columns=["fid"], errors="ignore")
+    village_service_gdf = admin_rows[["fid", "geometry"]].copy()
+    village_service_gdf["_admin_key"] = village_service_gdf["fid"]
+    village_service_gdf = village_service_gdf.merge(village_service_values, on="_admin_key", how="left")
+    village_service_gdf = gpd.GeoDataFrame(village_service_gdf, geometry="geometry", crs=admin_rows.crs)
+    status_name, status_outputs = status_column_config(config)
+    if status_name:
+        village_service_gdf[status_name] = [
+            _status_value(village_id, not nearest.empty)
+            for village_id in village_service_gdf["village_id"]
+        ]
+    describe_machine = _machine_column_describer(classification, config)
+    rename_machine = _machine_column_renamer(classification, config)
+    # Order the GeoPackage columns by the classification schema, then append any
+    # remaining columns (title, layer kind) so nothing is silently dropped.
+    present = set(village_service_gdf.columns)
+    gpkg_value_columns = [column for column in _machine_output_columns(classification) if column in present]
+    gpkg_value_columns.extend(
+        column
+        for column in village_service_gdf.columns
+        if column not in set(gpkg_value_columns) | {"geometry", "_admin_key", status_name}
+    )
+    if status_name and {"gpkg", "geoserver"} & status_outputs:
+        gpkg_value_columns.insert(0, status_name)
+    village_service_output_gdf = gpd.GeoDataFrame(
+        admin_output_frame(
+            village_service_gdf,
+            value_columns=gpkg_value_columns,
+            include_geometry=True,
+        ),
+        geometry="geometry",
+        crs=village_service_gdf.crs,
+    )
+    village_service_output_gdf = gpd.GeoDataFrame(
+        normalize_unicode_frame(village_service_output_gdf),
+        geometry="geometry",
+        crs=village_service_output_gdf.crs,
+    )
+    tehsil_facilities, village_nearest_facilities = _facility_point_outputs(
+        inventory,
+        nearest,
+    )
+    tehsil_facilities_layer = "tehsil_facility_collection"
+    village_nearest_layer = "village_nearest_facility_collection"
+    published_tehsil_facilities_layer = f"{layer_name}_{tehsil_facilities_layer}"
+    published_village_nearest_layer = f"{layer_name}_{village_nearest_layer}"
+
+    result: dict[str, Any] = {
+        "status": "success",
+        "algorithm": ALGORITHM,
+        "algorithm_version": ALGORITHM_VERSION,
+        "layer_name": layer_name,
+        "village_rows": int(len(admin_rows)),
+        "inventory_rows": int(len(inventory)),
+        "nearest_rows": int(len(nearest)),
+        "village_service_rows": int(len(village_service_output_gdf)),
+        "facility_point_layers": [tehsil_facilities_layer, village_nearest_layer],
+        "created_facility_indexes": created_facility_indexes,
+        "admin_created_indexes": admin_selection.created_indexes,
+        "state_name": request.scope.state_name,
+        "district_name": request.scope.district_name,
+        "tehsil": request.scope.tehsil_name,
+        "output_dir": bundle.path.as_posix(),
+        "sync_to_geoserver": request.publish.sync_to_geoserver,
+        **pool_metadata,
+    }
+
+    t0 = time.perf_counter()
+    paths: dict[str, str] = {}
+    bundle.remove_outputs(".csv", ".stac_fragment.json", ".geoserver_links.csv")
+    if outputs.gpkg or (request.publish.sync_to_geoserver and outputs.geoserver):
+        # The GPKG table name becomes the GeoServer feature-type name, so it
+        # must be the scoped layer name rather than a generic table name.
+        paths["gpkg_path"] = bundle.write_gpkg({layer_name: village_service_output_gdf}).as_posix()
+        paths["facility_points_gpkg_path"] = bundle.write_gpkg(
+            {
+                tehsil_facilities_layer: tehsil_facilities,
+                village_nearest_layer: village_nearest_facilities,
+            },
+            ".facility_points.gpkg",
+        ).as_posix()
+    result.update(paths)
+    timings["write_local_outputs_seconds"] = round(time.perf_counter() - t0, 3)
+
+    geoserver = None
+    published_layers: dict[str, dict[str, Any]] = {}
+    if request.publish.sync_to_geoserver and outputs.geoserver:
+        t0 = time.perf_counter()
+        gpkg_path = result.get("gpkg_path")
+        geoserver_workspace = (
+            request.publish.geoserver_workspace
+            or output_config.get("geoserver_workspace")
+            or FACILITIES_GEOSERVER_WORKSPACE
+        )
+        facility_points_gpkg_path = result.get("facility_points_gpkg_path")
+        if gpkg_path and facility_points_gpkg_path:
+            try:
+                geoserver_result = publish_gpkg_layer(
+                    gpkg_path,
+                    workspace=geoserver_workspace,
+                    layer_name=layer_name,
+                    overwrite=request.publish.overwrite,
+                )
+                geoserver = asdict(geoserver_result)
+                geoserver["ok"] = True
+                geoserver["status"] = "published"
+                published_layers["village_properties"] = geoserver
+                point_results = publish_gpkg_layers(
+                    facility_points_gpkg_path,
+                    workspace=geoserver_workspace,
+                    store_name=f"{layer_name}_facility_points",
+                    layers={
+                        published_tehsil_facilities_layer: tehsil_facilities_layer,
+                        published_village_nearest_layer: village_nearest_layer,
+                    },
+                    overwrite=request.publish.overwrite,
+                )
+                published_layers["tehsil_facility_collection"] = {
+                    **asdict(point_results[published_tehsil_facilities_layer]),
+                    "ok": True,
+                    "status": "published",
+                }
+                published_layers["village_nearest_facility_collection"] = {
+                    **asdict(point_results[published_village_nearest_layer]),
+                    "ok": True,
+                    "status": "published",
+                }
+            except Exception as exc:
+                geoserver = {
+                    "ok": False,
+                    "status": "publish_failed",
+                    "workspace": geoserver_workspace,
+                    "layer_name": layer_name,
+                    "gpkg_path": gpkg_path,
+                    "error_type": exc.__class__.__name__,
+                    "error": str(exc)[:500],
+                }
+        else:
+            geoserver = {
+                "ok": False,
+                "status": "missing_gpkg",
+                "workspace": geoserver_workspace,
+                "layer_name": layer_name,
+                "gpkg_path": gpkg_path,
+                "facility_points_gpkg_path": facility_points_gpkg_path,
+            }
+        timings["publish_geoserver_seconds"] = round(time.perf_counter() - t0, 3)
+    result["geoserver"] = geoserver
+    result["geoserver_layers"] = published_layers
+    if outputs.readme:
+        result["readme_path"] = bundle.write_readme(
+            _readme_lines(
+                request,
+                config,
+                layer_name,
+                result,
+                column_dictionary(
+                    pd.DataFrame(village_service_output_gdf.drop(columns=["geometry"], errors="ignore")),
+                    describe_machine,
+                    rename_machine,
+                ),
+            )
+        ).as_posix()
+    result["links_path"] = bundle.write_links(
+        {
+            "local": {
+                "village_properties": {
+                    "gpkg_path": result.get("gpkg_path"),
+                    "layer_name": layer_name,
+                },
+                "facility_points": {
+                    "gpkg_path": result.get("facility_points_gpkg_path"),
+                    "layers": [tehsil_facilities_layer, village_nearest_layer],
+                },
+                "readme_path": result.get("readme_path"),
+            },
+            "geoserver": {
+                "status": geoserver.get("status") if isinstance(geoserver, Mapping) else "not_requested",
+                "layers": published_layers,
+            },
+        }
+    ).as_posix()
+    if request.publish.register_layers and published_layers:
+        common_misc = {
+            "source_facilities_gpkg": config["sources"]["facilities_gpkg"],
+            "gpkg_path": result.get("gpkg_path"),
+            "facility_points_gpkg_path": result.get("facility_points_gpkg_path"),
+            "links_path": result.get("links_path"),
+            "output_dir": bundle.path.as_posix(),
+            "village_rows": result.get("village_rows"),
+            "nearest_rows": result.get("nearest_rows"),
+            "inventory_rows": result.get("inventory_rows"),
+        }
+        registrations: dict[str, dict[str, Any]] = {}
+        for role, published in published_layers.items():
+            registrations[role] = register_layer(
+                dataset_name=(
+                    output_config.get("dataset_name", "Facilities Proximity")
+                    if role == "village_properties"
+                    else output_config.get("points_dataset_name", "Facilities Points")
+                ),
+                layer_name=published["layer_name"],
+                scope=request.scope,
+                workspace=published["workspace"],
+                geoserver_url=published["wfs_url"],
+                algorithm=ALGORITHM,
+                algorithm_version=ALGORITHM_VERSION,
+                misc={**common_misc, "output_role": role},
+                overwrite=request.publish.overwrite,
+            )
+        result["layer_registrations"] = registrations
+        result["layer_registration"] = registrations.get("village_properties")
+        result["layer_id"] = (result.get("layer_registration") or {}).get("layer_id")
+    result["timings"] = timings
+    result["elapsed_seconds"] = round(time.perf_counter() - started, 3)
+    if outputs.metadata:
+        result["run_metadata_path"] = bundle.write_metadata(
+            {
+                "request": asdict(request),
+                "effective_outputs": asdict(outputs),
+                "result": result,
+                "config_path": str(config_path),
+                "outputs": {
+                    "village_properties": frame_profile(
+                        pd.DataFrame(village_service_output_gdf.drop(columns=["geometry"], errors="ignore")),
+                        describe_machine,
+                        rename_machine,
+                    ),
+                    "tehsil_facility_collection": frame_profile(
+                        pd.DataFrame(tehsil_facilities.drop(columns=["geometry"], errors="ignore")),
+                        _point_column_describer,
+                    ),
+                    "village_nearest_facility_collection": frame_profile(
+                        pd.DataFrame(village_nearest_facilities.drop(columns=["geometry"], errors="ignore")),
+                        _point_column_describer,
+                    ),
+                },
+            }
+        ).as_posix()
+    result["cache_manifest_path"] = bundle.write_cache_manifest(
+        {
+            "cache_key": cache_key,
+            "input_signatures": cache_signatures,
+            "required_result_paths": required_result_paths,
+            "result": result,
+        }
+    ).as_posix()
+    return result
+
+
+def run_facilities_request(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return run_facilities_pipeline(StandardRequest.from_mapping(payload))
+
+
+@app.task(bind=True, max_retries=3, default_retry_delay=60)
+def generate_facilities_proximity_task(self, payload: Mapping[str, Any]):
+    return run_facilities_request(payload)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the local facilities pipeline.")
+    parser.add_argument("--state")
+    parser.add_argument("--district")
+    parser.add_argument("--tehsil")
+    parser.add_argument("--no-geoserver", action="store_true")
+    args = parser.parse_args()
+    if not (args.state and args.district and args.tehsil):
+        parser.error("--state, --district, and --tehsil are required")
+    request = _cli_request(args.state, args.district, args.tehsil, not args.no_geoserver)
+    result = run_facilities_pipeline(request)
+    print(json.dumps(result, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds the configuration-driven facilities local pipeline using the standard admin and pan-India facilities assets.
- Uses the shared module from `utilities.pipelines`.
- Produces village proximity outputs and the required two-layer facilities point GeoPackage.
- Adds standardized metadata, README, links, validation, cache reuse, and structured API payload handling.

## Validation

Tested through the Facilities API for:

- State: Jharkhand
- District: Dumka
- Tehsil: Masalia

Results:

- API returned HTTP 200.
- Processed 307 villages.
- Produced 796 tehsil facility points.
- Produced 7,675 village-nearest rows.
- Both required GeoPackage layers passed.
- No rejected GeoLibre or batch artifacts, result keys, or links were produced.