### PR TITLE
Clean local pipeline village identities and resource paths

### DIFF
--- a/computing/misc/antyodaya/antyodaya_pipeline.yaml
+++ b/computing/misc/antyodaya/antyodaya_pipeline.yaml
@@ -5,11 +5,12 @@ description: >
   joined at runtime to the Core Stack standard admin boundary.
 
 sources:
-  admin_gpkg: data/admin-boundary/cs_admin_standard.gpkg
+  # Optional test overrides; canonical defaults come from utilities/constants.py.
+  # admin_gpkg: data/tests/fixtures/cs_admin_standard.gpkg
   admin_layer: cs_admin_standard
-  csv: data/base_resources/cs_antyodaya_2020_cluster_analysis.csv
+  # csv: data/tests/fixtures/cs_antyodaya_2020_cluster_analysis.csv
   mapping_yaml: computing/misc/antyodaya/antyodaya_2020_mapping.yaml
-  sidecar_sqlite: data/base_resources/cs_antyodaya_2020_cluster_analysis.csv.sqlite
+  # sidecar_sqlite: data/tests/fixtures/cs_antyodaya_2020_cluster_analysis.csv.sqlite
   report_pdf: docs/reports/antyodaya_cluster_analysis_report.pdf
   blog_pdf: docs/reports/antyodaya_cluster_analysis_blog.pdf
   report_url: https://github.com/core-stack-org/core-stack-backend/blob/main/docs/reports/antyodaya_cluster_analysis_report.pdf

--- a/computing/misc/antyodaya/antyodaya_pipeline.yaml
+++ b/computing/misc/antyodaya/antyodaya_pipeline.yaml
@@ -10,7 +10,6 @@ sources:
   admin_layer: cs_admin_standard
   # csv: data/tests/fixtures/cs_antyodaya_2020_cluster_analysis.csv
   mapping_yaml: computing/misc/antyodaya/antyodaya_2020_mapping.yaml
-  # sidecar_sqlite: data/tests/fixtures/cs_antyodaya_2020_cluster_analysis.csv.sqlite
   report_pdf: docs/reports/antyodaya_cluster_analysis_report.pdf
   blog_pdf: docs/reports/antyodaya_cluster_analysis_blog.pdf
   report_url: https://github.com/core-stack-org/core-stack-backend/blob/main/docs/reports/antyodaya_cluster_analysis_report.pdf

--- a/computing/misc/antyodaya/antyodaya_pipeline.yaml
+++ b/computing/misc/antyodaya/antyodaya_pipeline.yaml
@@ -22,7 +22,8 @@ keys:
   source_unique_key: village_key
 
 output:
-  root: data/tests/outputs/antyodaya20
+  root: data/outputs
+  directory_name: antyodaya20
   layer_prefix: antyodaya20
   geoserver_workspace: testworkspace
   # Dataset row used when registering published layers in the Layer database.

--- a/computing/misc/antyodaya/antyodaya_pipeline.yaml
+++ b/computing/misc/antyodaya/antyodaya_pipeline.yaml
@@ -44,7 +44,6 @@ output_contract:
     outputs: [gpkg, geoserver]
 
 source_location_columns:
-  - village_key
   - state_code
   - district_code
   - sub_district_code

--- a/computing/misc/antyodaya/pipeline.py
+++ b/computing/misc/antyodaya/pipeline.py
@@ -87,7 +87,11 @@ def _source_columns(config: Mapping[str, Any]) -> dict[str, list[str]]:
     feature_value = [col for col in header if col.endswith(validation["feature_value_suffix"])]
     metric_columns = set(category_cluster + category_value + feature_value)
     location_columns = [col for col in config["source_location_columns"] if col in header]
-    excluded_raw = set(location_columns) | metric_columns
+    source_identity_columns = {
+        config["keys"]["source_join_key"],
+        config["keys"]["source_unique_key"],
+    }
+    excluded_raw = set(location_columns) | source_identity_columns | metric_columns
     raw_columns = [col for col in header if col not in excluded_raw]
     return {
         "header": header,
@@ -269,8 +273,6 @@ def _column_describer(config: Mapping[str, Any], columns: Mapping[str, list[str]
                 f"`{STATUS_NO_VILLAGE_ID}` when the admin row lacks a village identifier, and "
                 f"`{STATUS_NO_DATA}` when no Antyodaya record matched this village."
             )
-        if name == "village_key":
-            return "Unique Mission Antyodaya 2020 village record key."
         if name.endswith(cluster_suffix):
             return (
                 f"Relative class (LOW/MEDIUM/HIGH) of the {title_for(name[: -len(cluster_suffix)])} category "
@@ -484,9 +486,14 @@ def run_antyodaya_pipeline(
     _normalize_category_clusters(source_rows, columns["category_cluster"])
     validation_issues = _validate_antyodaya(source_rows, config)
     joined = _merge_admin_antyodaya(admin_selection.rows, source_rows, config)
+    village_keys = (
+        joined["village_key"]
+        if "village_key" in joined.columns
+        else pd.Series([None] * len(joined), index=joined.index)
+    )
+    matched_rows = int(village_keys.notna().sum())
     status_name, status_outputs = status_column_config(config)
     if status_name:
-        village_keys = joined["village_key"] if "village_key" in joined.columns else pd.Series([None] * len(joined), index=joined.index)
         joined[status_name] = [
             STATUS_NO_VILLAGE_ID
             if pd.isna(village_id)
@@ -495,7 +502,6 @@ def run_antyodaya_pipeline(
         ]
     ordered_columns = _ordered_tabular_columns(joined, columns)
     villages_frame = admin_output_frame(joined.drop(columns=["geometry"], errors="ignore"), value_columns=ordered_columns)
-    matched_rows = int(villages_frame["village_key"].notna().sum()) if "village_key" in villages_frame else 0
     gpkg_value_columns = list(ordered_columns)
     if status_name and {"gpkg", "geoserver"} & status_outputs:
         gpkg_value_columns = [status_name, *gpkg_value_columns]

--- a/computing/misc/antyodaya/pipeline.py
+++ b/computing/misc/antyodaya/pipeline.py
@@ -44,12 +44,22 @@ from utilities.pipelines.schema import (
 from utilities.pipelines.tabular import CSVSQLiteSidecar, csv_header
 from utilities.pipelines.unicode import normalize_unicode_frame
 from nrm_app.celery import app
-from utilities.constants import ANTYODAYA_GEOSERVER_WORKSPACE
+from utilities.constants import (
+    ADMIN_BOUNDARY_GPKG,
+    ANTYODAYA_2020_CSV,
+    ANTYODAYA_2020_SIDECAR_SQLITE,
+    ANTYODAYA_GEOSERVER_WORKSPACE,
+)
 
 
 CONFIG_PATH = Path(__file__).with_name("antyodaya_pipeline.yaml")
 ALGORITHM = "local-antyodaya-csv-admin-join"
 ALGORITHM_VERSION = "2.0"
+SOURCE_DEFAULTS = {
+    "admin_gpkg": ADMIN_BOUNDARY_GPKG,
+    "csv": ANTYODAYA_2020_CSV,
+    "sidecar_sqlite": ANTYODAYA_2020_SIDECAR_SQLITE,
+}
 
 
 def _repo_path(path: str | Path) -> Path:
@@ -58,6 +68,17 @@ def _repo_path(path: str | Path) -> Path:
         return path
     base_dir = Path(settings.BASE_DIR) if settings.configured else Path.cwd()
     return base_dir / path
+
+
+def _apply_source_defaults(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Use constants for production resources and YAML only for overrides."""
+
+    resolved = dict(config)
+    sources = dict(resolved.get("sources") or {})
+    for name, default in SOURCE_DEFAULTS.items():
+        sources[name] = sources.get(name) or default
+    resolved["sources"] = sources
+    return resolved
 
 
 def _layer_name(prefix: str, district: str | None, tehsil: str | None) -> str:
@@ -446,7 +467,7 @@ def run_antyodaya_pipeline(
 
     started = time.perf_counter()
     timings: dict[str, float] = {}
-    config = load_config(config_path)
+    config = _apply_source_defaults(load_config(config_path))
     outputs = resolve_output_options(request, config)
     columns = _source_columns(config)
     output_config = config["output"]

--- a/computing/misc/antyodaya/pipeline.py
+++ b/computing/misc/antyodaya/pipeline.py
@@ -47,7 +47,6 @@ from nrm_app.celery import app
 from utilities.constants import (
     ADMIN_BOUNDARY_GPKG,
     ANTYODAYA_2020_CSV,
-    ANTYODAYA_2020_SIDECAR_SQLITE,
     ANTYODAYA_GEOSERVER_WORKSPACE,
 )
 
@@ -58,7 +57,6 @@ ALGORITHM_VERSION = "2.0"
 SOURCE_DEFAULTS = {
     "admin_gpkg": ADMIN_BOUNDARY_GPKG,
     "csv": ANTYODAYA_2020_CSV,
-    "sidecar_sqlite": ANTYODAYA_2020_SIDECAR_SQLITE,
 }
 
 
@@ -77,6 +75,9 @@ def _apply_source_defaults(config: Mapping[str, Any]) -> dict[str, Any]:
     sources = dict(resolved.get("sources") or {})
     for name, default in SOURCE_DEFAULTS.items():
         sources[name] = sources.get(name) or default
+    sources["sidecar_sqlite"] = (
+        sources.get("sidecar_sqlite") or f"{sources['csv']}.sqlite"
+    )
     resolved["sources"] = sources
     return resolved
 

--- a/computing/misc/antyodaya/pipeline.py
+++ b/computing/misc/antyodaya/pipeline.py
@@ -475,7 +475,11 @@ def run_antyodaya_pipeline(
     layer_name = _layer_name(output_config["layer_prefix"], request.scope.district_name, request.scope.tehsil_name)
     result_name = layer_name or f"{output_config['layer_prefix']}_{slug(request.scope.level)}"
     output_root = _repo_path(output_config["root"]) / slug(request.scope.state_name) / slug(request.scope.district_name) / slug(request.scope.tehsil_name)
-    bundle = OutputBundle(output_root, result_name)
+    bundle = OutputBundle(
+        output_root,
+        result_name,
+        directory_name=output_config["directory_name"],
+    )
     cache_key = _cache_key(request, outputs)
     cache_signatures = _cache_input_signatures(config, config_path)
     required_result_paths = _required_result_paths(outputs, request)

--- a/computing/misc/facilities/facilities_pipeline.yaml
+++ b/computing/misc/facilities/facilities_pipeline.yaml
@@ -70,8 +70,6 @@ facility_columns:
   - pincode
   - establishment_year
   - district_lgd
-  - village_census11
-  - village_name
   - membership_count
 
 readme:

--- a/computing/misc/facilities/facilities_pipeline.yaml
+++ b/computing/misc/facilities/facilities_pipeline.yaml
@@ -5,9 +5,10 @@ description: >
   cs_pan_india_facilities.gpkg and cs_admin_standard.gpkg.
 
 sources:
-  admin_gpkg: data/admin-boundary/cs_admin_standard.gpkg
+  # Optional test overrides; canonical defaults come from utilities/constants.py.
+  # admin_gpkg: data/tests/fixtures/cs_admin_standard.gpkg
   admin_layer: cs_admin_standard
-  facilities_gpkg: data/facilities/outputs/cs_pan_india_facilities.gpkg
+  # facilities_gpkg: data/tests/fixtures/cs_pan_india_facilities.gpkg
   facilities_layer: facilities
   taxonomy_table: facility_taxonomy
   classification_yaml: computing/misc/facilities/facility_classifications.yaml

--- a/computing/misc/facilities/facilities_pipeline.yaml
+++ b/computing/misc/facilities/facilities_pipeline.yaml
@@ -14,7 +14,8 @@ sources:
   classification_yaml: computing/misc/facilities/facility_classifications.yaml
 
 output:
-  root: data/tests/outputs/facilities
+  root: data/outputs
+  directory_name: facilities
   layer_prefix: facilities
   geoserver_workspace: testworkspace
   # Dataset row used when registering published layers in the Layer database.

--- a/computing/misc/facilities/pipeline.py
+++ b/computing/misc/facilities/pipeline.py
@@ -19,6 +19,7 @@ from scipy.spatial import cKDTree
 from utilities.pipelines import AdminScope, CSAdminSource, StandardRequest, load_config
 from utilities.pipelines.admin import (
     ADMIN_COLUMN_DESCRIPTIONS,
+    ADMIN_PRESENTATION_COLUMNS,
     admin_output_frame,
     admin_presentation_frame,
 )
@@ -229,7 +230,20 @@ def _read_facilities_bbox(
 def _inventory(candidates: gpd.GeoDataFrame, admin_rows) -> gpd.GeoDataFrame:
     if candidates.empty:
         return candidates
-    admin_context = admin_rows[["fid", "pc11_village_id", "village_id", "NAME", "state_name", "district_name", "TEHSIL", "geometry"]].copy()
+    admin_context = admin_rows[
+        [
+            "fid",
+            "pc11_state_id",
+            "pc11_district_id",
+            "pc11_subdistrict_id",
+            "village_id",
+            "NAME",
+            "state_name",
+            "district_name",
+            "TEHSIL",
+            "geometry",
+        ]
+    ].copy()
     admin_context["_admin_key"] = admin_context["fid"]
     joined = gpd.sjoin(candidates, admin_context, how="inner", predicate="intersects")
     if "index_right" in joined.columns:
@@ -326,7 +340,9 @@ def _nearest(
             row = {
                 "_admin_key": village.get("_admin_key"),
                 "fid": village.get("fid"),
-                "pc11_village_id": village.get("pc11_village_id"),
+                "pc11_state_id": village.get("pc11_state_id"),
+                "pc11_district_id": village.get("pc11_district_id"),
+                "pc11_subdistrict_id": village.get("pc11_subdistrict_id"),
                 "village_id": village.get("village_id"),
                 "village_name": village.get("NAME"),
                 "state_name": village.get("state_name"),
@@ -351,7 +367,6 @@ def _nearest(
                 "class_l4_facility_subtype",
                 "urban_rural",
                 "pincode",
-                "village_census11",
             ]:
                 row[column] = facility.get(column)
             row["geometry"] = facility.geometry
@@ -594,11 +609,39 @@ def _machine_column_renamer(classification: Mapping[str, Any], config: Mapping[s
     return rename
 
 
-def _drop_pc11_output_columns(frame: pd.DataFrame) -> pd.DataFrame:
-    """Remove redundant source Census identifiers from user-facing outputs."""
+def _canonical_facility_point_output(frame: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """Keep one standard admin identity and discard source village aliases."""
 
-    columns = [column for column in frame.columns if str(column).lower().startswith("pc11")]
-    return frame.drop(columns=columns, errors="ignore")
+    output = frame.drop(
+        columns=[
+            "pc11_village_id",
+            "village_census11",
+            "admin_village_name",
+        ],
+        errors="ignore",
+    ).rename(
+        columns={
+            "pc11_state_id": "state_id",
+            "pc11_district_id": "district_id",
+            "pc11_subdistrict_id": "tehsil_id",
+            "TEHSIL": "tehsil_name",
+            "NAME": "village_name",
+        }
+    )
+    admin_columns = [column for column in ADMIN_PRESENTATION_COLUMNS if column in output.columns]
+    value_columns = [
+        column
+        for column in output.columns
+        if column not in {*admin_columns, "geometry"}
+    ]
+    ordered = [*admin_columns, *value_columns]
+    if "geometry" in output.columns:
+        ordered.append("geometry")
+    return gpd.GeoDataFrame(
+        normalize_unicode_frame(output.reindex(columns=ordered)),
+        geometry="geometry",
+        crs=frame.crs,
+    )
 
 
 def _facility_point_outputs(
@@ -608,23 +651,20 @@ def _facility_point_outputs(
     """Return the two clean point layers in the facilities collection."""
 
     inventory_output = inventory.drop(
-        columns=["_admin_key", "index_right"], errors="ignore"
+        columns=["_admin_key", "index_right", "village_name", "village_census11"],
+        errors="ignore",
     ).rename(
         columns={
             "fid_left": "facility_source_fid",
-            "fid_right": "admin_source_fid",
-            "NAME": "admin_village_name",
-            "TEHSIL": "tehsil_name",
+            "fid_right": "index",
         }
     )
-    nearest_output = nearest.drop(columns=["_admin_key", "fid"], errors="ignore").rename(
-        columns={"TEHSIL": "tehsil_name"}
+    nearest_output = nearest.drop(columns=["_admin_key"], errors="ignore").rename(
+        columns={"fid": "index"}
     )
-    inventory_output = _drop_pc11_output_columns(inventory_output)
-    nearest_output = _drop_pc11_output_columns(nearest_output)
     return (
-        gpd.GeoDataFrame(normalize_unicode_frame(inventory_output), geometry="geometry", crs=inventory.crs),
-        gpd.GeoDataFrame(normalize_unicode_frame(nearest_output), geometry="geometry", crs=nearest.crs),
+        _canonical_facility_point_output(inventory_output),
+        _canonical_facility_point_output(nearest_output),
     )
 
 
@@ -643,8 +683,6 @@ def _point_column_describer(name: str) -> str | None:
         "facilities_layer_kind": "Facilities output role for this feature.",
         "title": "Human-readable facility title used by map viewers.",
         "facility_source_fid": "Internal feature identifier from the facilities source GeoPackage.",
-        "admin_source_fid": "Internal feature identifier from the administrative source GeoPackage.",
-        "admin_village_name": "Village name from the administrative boundary source.",
         "latitude": "Facility latitude in decimal degrees (WGS84).",
         "longitude": "Facility longitude in decimal degrees (WGS84).",
         "class_l4_facility_subtype": "Detailed source facility subtype when available.",
@@ -652,7 +690,6 @@ def _point_column_describer(name: str) -> str | None:
         "pincode": "Postal PIN code associated with the facility.",
         "establishment_year": "Year the facility was established when available.",
         "district_lgd": "Local Government Directory district code from the facility source.",
-        "village_census11": "Census 2011 village code associated with the facility source.",
         "membership_count": "Source membership count where the facility represents an institution or collective.",
         "service_level": "Taxonomy level used for the nearest-facility association.",
     }
@@ -926,11 +963,6 @@ def run_facilities_pipeline(
     )
     village_service_output_gdf = gpd.GeoDataFrame(
         normalize_unicode_frame(village_service_output_gdf),
-        geometry="geometry",
-        crs=village_service_output_gdf.crs,
-    )
-    village_service_output_gdf = gpd.GeoDataFrame(
-        _drop_pc11_output_columns(village_service_output_gdf),
         geometry="geometry",
         crs=village_service_output_gdf.crs,
     )

--- a/computing/misc/facilities/pipeline.py
+++ b/computing/misc/facilities/pipeline.py
@@ -57,12 +57,20 @@ from utilities.pipelines.publish import (
 )
 from utilities.pipelines.unicode import normalize_unicode_frame
 from nrm_app.celery import app
-from utilities.constants import FACILITIES_GEOSERVER_WORKSPACE
+from utilities.constants import (
+    ADMIN_BOUNDARY_GPKG,
+    FACILITIES_GEOSERVER_WORKSPACE,
+    FACILITIES_GPKG,
+)
 
 
 CONFIG_PATH = Path(__file__).with_name("facilities_pipeline.yaml")
 ALGORITHM = "local-facilities-live-proximity"
 ALGORITHM_VERSION = "2.0"
+SOURCE_DEFAULTS = {
+    "admin_gpkg": ADMIN_BOUNDARY_GPKG,
+    "facilities_gpkg": FACILITIES_GPKG,
+}
 
 
 def _repo_path(path: str | Path) -> Path:
@@ -71,6 +79,17 @@ def _repo_path(path: str | Path) -> Path:
         return path
     base_dir = Path(settings.BASE_DIR) if settings.configured else Path.cwd()
     return base_dir / path
+
+
+def _apply_source_defaults(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Use constants for production resources and YAML only for overrides."""
+
+    resolved = dict(config)
+    sources = dict(resolved.get("sources") or {})
+    for name, default in SOURCE_DEFAULTS.items():
+        sources[name] = sources.get(name) or default
+    resolved["sources"] = sources
+    return resolved
 
 
 def _layer_name(prefix: str, district: str | None, tehsil: str | None) -> str:
@@ -879,7 +898,7 @@ def run_facilities_pipeline(
 ) -> dict[str, Any]:
     started = time.perf_counter()
     timings: dict[str, float] = {}
-    config = load_config(config_path)
+    config = _apply_source_defaults(load_config(config_path))
     outputs = resolve_output_options(request, config)
     output_config = config["output"]
     output_parts, layer_name = scope_output_identity(output_config["layer_prefix"], request.scope)

--- a/computing/misc/facilities/pipeline.py
+++ b/computing/misc/facilities/pipeline.py
@@ -903,7 +903,11 @@ def run_facilities_pipeline(
     output_config = config["output"]
     output_parts, layer_name = scope_output_identity(output_config["layer_prefix"], request.scope)
     output_root = _repo_path(output_config["root"]).joinpath(*output_parts)
-    bundle = OutputBundle(output_root, layer_name)
+    bundle = OutputBundle(
+        output_root,
+        layer_name,
+        directory_name=output_config["directory_name"],
+    )
     cache_key = _cache_key(request, outputs)
     cache_signatures = _cache_input_signatures(config, config_path)
     required_result_paths = _required_result_paths(outputs, request)

--- a/computing/misc/facilities/pipeline.py
+++ b/computing/misc/facilities/pipeline.py
@@ -594,6 +594,13 @@ def _machine_column_renamer(classification: Mapping[str, Any], config: Mapping[s
     return rename
 
 
+def _drop_pc11_output_columns(frame: pd.DataFrame) -> pd.DataFrame:
+    """Remove redundant source Census identifiers from user-facing outputs."""
+
+    columns = [column for column in frame.columns if str(column).lower().startswith("pc11")]
+    return frame.drop(columns=columns, errors="ignore")
+
+
 def _facility_point_outputs(
     inventory: gpd.GeoDataFrame,
     nearest: gpd.GeoDataFrame,
@@ -613,6 +620,8 @@ def _facility_point_outputs(
     nearest_output = nearest.drop(columns=["_admin_key", "fid"], errors="ignore").rename(
         columns={"TEHSIL": "tehsil_name"}
     )
+    inventory_output = _drop_pc11_output_columns(inventory_output)
+    nearest_output = _drop_pc11_output_columns(nearest_output)
     return (
         gpd.GeoDataFrame(normalize_unicode_frame(inventory_output), geometry="geometry", crs=inventory.crs),
         gpd.GeoDataFrame(normalize_unicode_frame(nearest_output), geometry="geometry", crs=nearest.crs),
@@ -635,7 +644,6 @@ def _point_column_describer(name: str) -> str | None:
         "title": "Human-readable facility title used by map viewers.",
         "facility_source_fid": "Internal feature identifier from the facilities source GeoPackage.",
         "admin_source_fid": "Internal feature identifier from the administrative source GeoPackage.",
-        "pc11_village_id": "Population Census 2011 village identifier.",
         "admin_village_name": "Village name from the administrative boundary source.",
         "latitude": "Facility latitude in decimal degrees (WGS84).",
         "longitude": "Facility longitude in decimal degrees (WGS84).",
@@ -918,6 +926,11 @@ def run_facilities_pipeline(
     )
     village_service_output_gdf = gpd.GeoDataFrame(
         normalize_unicode_frame(village_service_output_gdf),
+        geometry="geometry",
+        crs=village_service_output_gdf.crs,
+    )
+    village_service_output_gdf = gpd.GeoDataFrame(
+        _drop_pc11_output_columns(village_service_output_gdf),
         geometry="geometry",
         crs=village_service_output_gdf.crs,
     )

--- a/computing/misc/livestocks/livestocks_pipeline.yaml
+++ b/computing/misc/livestocks/livestocks_pipeline.yaml
@@ -9,7 +9,6 @@ sources:
   # admin_gpkg: data/tests/fixtures/cs_admin_standard.gpkg
   admin_layer: cs_admin_standard
   # csv: data/tests/fixtures/cs_livestock_census_20.csv
-  # sidecar_sqlite: data/tests/fixtures/cs_livestock_census_20.csv.sqlite
   schema_yaml: computing/misc/livestocks/livestocks_schema.yaml
 
 keys:

--- a/computing/misc/livestocks/livestocks_pipeline.yaml
+++ b/computing/misc/livestocks/livestocks_pipeline.yaml
@@ -5,10 +5,11 @@ description: >
   standard admin boundary.
 
 sources:
-  admin_gpkg: data/admin-boundary/cs_admin_standard.gpkg
+  # Optional test overrides; canonical defaults come from utilities/constants.py.
+  # admin_gpkg: data/tests/fixtures/cs_admin_standard.gpkg
   admin_layer: cs_admin_standard
-  csv: data/base_resources/cs_livestock_census_20.csv
-  sidecar_sqlite: data/base_resources/cs_livestock_census_20.csv.sqlite
+  # csv: data/tests/fixtures/cs_livestock_census_20.csv
+  # sidecar_sqlite: data/tests/fixtures/cs_livestock_census_20.csv.sqlite
   schema_yaml: computing/misc/livestocks/livestocks_schema.yaml
 
 keys:

--- a/computing/misc/livestocks/livestocks_pipeline.yaml
+++ b/computing/misc/livestocks/livestocks_pipeline.yaml
@@ -16,7 +16,8 @@ keys:
   source_join_key: village_code
 
 output:
-  root: data/tests/outputs/livestock20
+  root: data/outputs
+  directory_name: livestocks20
   layer_prefix: livestocks
   geoserver_workspace: testworkspace
   # Dataset row used when registering published layers in the Layer database.

--- a/computing/misc/livestocks/pipeline.py
+++ b/computing/misc/livestocks/pipeline.py
@@ -44,7 +44,6 @@ from nrm_app.celery import app
 from utilities.constants import (
     ADMIN_BOUNDARY_GPKG,
     LIVESTOCK_CENSUS_20_CSV,
-    LIVESTOCK_CENSUS_20_SIDECAR_SQLITE,
     LIVESTOCK_GEOSERVER_WORKSPACE,
 )
 
@@ -55,7 +54,6 @@ ALGORITHM_VERSION = "2.0"
 SOURCE_DEFAULTS = {
     "admin_gpkg": ADMIN_BOUNDARY_GPKG,
     "csv": LIVESTOCK_CENSUS_20_CSV,
-    "sidecar_sqlite": LIVESTOCK_CENSUS_20_SIDECAR_SQLITE,
 }
 
 
@@ -74,6 +72,9 @@ def _apply_source_defaults(config: Mapping[str, Any]) -> dict[str, Any]:
     sources = dict(resolved.get("sources") or {})
     for name, default in SOURCE_DEFAULTS.items():
         sources[name] = sources.get(name) or default
+    sources["sidecar_sqlite"] = (
+        sources.get("sidecar_sqlite") or f"{sources['csv']}.sqlite"
+    )
     resolved["sources"] = sources
     return resolved
 

--- a/computing/misc/livestocks/pipeline.py
+++ b/computing/misc/livestocks/pipeline.py
@@ -375,7 +375,11 @@ def run_livestocks_pipeline(
     output_config = config["output"]
     layer_name = _layer_name(output_config["layer_prefix"], request.scope.district_name, request.scope.tehsil_name)
     output_root = _repo_path(output_config["root"]) / slug(request.scope.state_name) / slug(request.scope.district_name) / slug(request.scope.tehsil_name)
-    bundle = OutputBundle(output_root, layer_name)
+    bundle = OutputBundle(
+        output_root,
+        layer_name,
+        directory_name=output_config["directory_name"],
+    )
     cache_key = _cache_key(request, outputs)
     cache_signatures = _cache_input_signatures(config, config_path)
     required_result_paths = _required_result_paths(outputs, request)

--- a/computing/misc/livestocks/pipeline.py
+++ b/computing/misc/livestocks/pipeline.py
@@ -41,12 +41,22 @@ from utilities.pipelines.schema import (
 from utilities.pipelines.tabular import CSVSQLiteSidecar, csv_header
 from utilities.pipelines.unicode import normalize_unicode_frame
 from nrm_app.celery import app
-from utilities.constants import LIVESTOCK_GEOSERVER_WORKSPACE
+from utilities.constants import (
+    ADMIN_BOUNDARY_GPKG,
+    LIVESTOCK_CENSUS_20_CSV,
+    LIVESTOCK_CENSUS_20_SIDECAR_SQLITE,
+    LIVESTOCK_GEOSERVER_WORKSPACE,
+)
 
 
 CONFIG_PATH = Path(__file__).with_name("livestocks_pipeline.yaml")
 ALGORITHM = "local-livestock-csv-admin-join"
 ALGORITHM_VERSION = "2.0"
+SOURCE_DEFAULTS = {
+    "admin_gpkg": ADMIN_BOUNDARY_GPKG,
+    "csv": LIVESTOCK_CENSUS_20_CSV,
+    "sidecar_sqlite": LIVESTOCK_CENSUS_20_SIDECAR_SQLITE,
+}
 
 
 def _repo_path(path: str | Path) -> Path:
@@ -55,6 +65,17 @@ def _repo_path(path: str | Path) -> Path:
         return path
     base_dir = Path(settings.BASE_DIR) if settings.configured else Path.cwd()
     return base_dir / path
+
+
+def _apply_source_defaults(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Use constants for production resources and YAML only for overrides."""
+
+    resolved = dict(config)
+    sources = dict(resolved.get("sources") or {})
+    for name, default in SOURCE_DEFAULTS.items():
+        sources[name] = sources.get(name) or default
+    resolved["sources"] = sources
+    return resolved
 
 
 def _layer_name(prefix: str, district: str | None, tehsil: str | None) -> str:
@@ -346,7 +367,7 @@ def run_livestocks_pipeline(
 ) -> dict[str, Any]:
     started = time.perf_counter()
     timings: dict[str, float] = {}
-    config = load_config(config_path)
+    config = _apply_source_defaults(load_config(config_path))
     outputs = resolve_output_options(request, config)
     schema = _schema(config)
     columns = _source_columns(config)

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -5,11 +5,24 @@ from nrm_app.settings import GEE_STORAGE_PROJECT, GEE_STORAGE_PROJECT_HELPER
 ADMIN_BOUNDARY_INPUT_DIR = "data/admin-boundary/input"
 ADMIN_BOUNDARY_OUTPUT_DIR = "data/admin-boundary/output"
 
+# Canonical local pipeline resources. Runtime pipelines read these defaults
+# directly; their YAML `sources` entries are optional test overrides.
+BASE_RESOURCES_DIR = "data/base_resources"
+ADMIN_BOUNDARY_GPKG = f"{BASE_RESOURCES_DIR}/cs_admin_standard.gpkg"
+FACILITIES_GPKG = f"{BASE_RESOURCES_DIR}/cs_pan_india_facilities.gpkg"
+ANTYODAYA_2020_GPKG = f"{BASE_RESOURCES_DIR}/cs_antyodaya_2020.gpkg"
+ANTYODAYA_2020_CSV = f"{BASE_RESOURCES_DIR}/cs_antyodaya_2020_cluster_analysis.csv"
+ANTYODAYA_2020_SIDECAR_SQLITE = f"{ANTYODAYA_2020_CSV}.sqlite"
+LIVESTOCK_CENSUS_20_GPKG = f"{BASE_RESOURCES_DIR}/cs_village_livestock_census_20.gpkg"
+LIVESTOCK_CENSUS_20_CSV = f"{BASE_RESOURCES_DIR}/cs_livestock_census_20.csv"
+LIVESTOCK_CENSUS_20_SIDECAR_SQLITE = f"{LIVESTOCK_CENSUS_20_CSV}.sqlite"
+
 NREGA_ASSETS_INPUT_DIR = "data/nrega_assets/input"
 NREGA_ASSETS_OUTPUT_DIR = "data/nrega_assets/output"
 
-ANTYODAYA_2020 = "data/local_resources/pan_india_antyodaya_2020.gpkg"
-LIVESTOCKS = "data/local_resources/pan_india_livestock.gpkg"
+# Compatibility names used by the legacy clipping modules.
+ANTYODAYA_2020 = ANTYODAYA_2020_GPKG
+LIVESTOCKS = LIVESTOCK_CENSUS_20_GPKG
 
 MERGE_MWS_PATH = "data/merge_mws"
 

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -10,19 +10,11 @@ ADMIN_BOUNDARY_OUTPUT_DIR = "data/admin-boundary/output"
 BASE_RESOURCES_DIR = "data/base_resources"
 ADMIN_BOUNDARY_GPKG = f"{BASE_RESOURCES_DIR}/cs_admin_standard.gpkg"
 FACILITIES_GPKG = f"{BASE_RESOURCES_DIR}/cs_pan_india_facilities.gpkg"
-ANTYODAYA_2020_GPKG = f"{BASE_RESOURCES_DIR}/cs_antyodaya_2020.gpkg"
 ANTYODAYA_2020_CSV = f"{BASE_RESOURCES_DIR}/cs_antyodaya_2020_cluster_analysis.csv"
-ANTYODAYA_2020_SIDECAR_SQLITE = f"{ANTYODAYA_2020_CSV}.sqlite"
-LIVESTOCK_CENSUS_20_GPKG = f"{BASE_RESOURCES_DIR}/cs_village_livestock_census_20.gpkg"
 LIVESTOCK_CENSUS_20_CSV = f"{BASE_RESOURCES_DIR}/cs_livestock_census_20.csv"
-LIVESTOCK_CENSUS_20_SIDECAR_SQLITE = f"{LIVESTOCK_CENSUS_20_CSV}.sqlite"
 
 NREGA_ASSETS_INPUT_DIR = "data/nrega_assets/input"
 NREGA_ASSETS_OUTPUT_DIR = "data/nrega_assets/output"
-
-# Compatibility names used by the legacy clipping modules.
-ANTYODAYA_2020 = ANTYODAYA_2020_GPKG
-LIVESTOCKS = LIVESTOCK_CENSUS_20_GPKG
 
 MERGE_MWS_PATH = "data/merge_mws"
 

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -8,8 +8,8 @@ ADMIN_BOUNDARY_OUTPUT_DIR = "data/admin-boundary/output"
 NREGA_ASSETS_INPUT_DIR = "data/nrega_assets/input"
 NREGA_ASSETS_OUTPUT_DIR = "data/nrega_assets/output"
 
-ANTYODAYA_2020 = "data/antyodaya/output/pan_india_antyodaya_2020.gpkg"
-LIVESTOCKS = "data/livestock/pan_india_livestock.gpkg"
+ANTYODAYA_2020 = "data/local_resources/pan_india_antyodaya_2020.gpkg"
+LIVESTOCKS = "data/local_resources/pan_india_livestock.gpkg"
 
 MERGE_MWS_PATH = "data/merge_mws"
 

--- a/utilities/pipelines/admin.py
+++ b/utilities/pipelines/admin.py
@@ -12,7 +12,7 @@ import pandas as pd
 try:
     from utilities.constants import ADMIN_BOUNDARY_GPKG
 except ImportError:
-    ADMIN_BOUNDARY_GPKG = "data/admin-boundary/cs_admin_standard.gpkg"
+    ADMIN_BOUNDARY_GPKG = "data/base_resources/cs_admin_standard.gpkg"
 
 from .gpkg import (
     IndexSpec,

--- a/utilities/pipelines/outputs.py
+++ b/utilities/pipelines/outputs.py
@@ -251,13 +251,14 @@ class OutputBundle:
 
     root: str | Path
     name: str
+    directory_name: str | None = None
 
     def __post_init__(self) -> None:
         self.root = Path(self.root)
 
     @property
     def path(self) -> Path:
-        return self.root / slug(self.name)
+        return self.root / slug(self.directory_name or self.name)
 
     def ensure(self) -> Path:
         self.path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What changed

- keeps five canonical local resource constants: base directory, admin GPKG, Facilities GPKG, Antyodaya CSV, and Livestock CSV
- writes each final pipeline bundle directly under `data/outputs/{state}/{district}/{tehsil}/{facilities|antyodaya20|livestocks20}`
- keeps deterministic scoped filenames while removing the extra scoped-layer directory level

## Validation

- Python compile, YAML parse, five-constant resolution, derived-sidecar, explicit-override, path-existence, and diff checks passed
- Facilities Masalia run: 307 villages, 796 inventory points, 7,675 nearest associations
- Antyodaya Masalia run: 307 rows, 281 matches, 0.915309 coverage
- Livestock Masalia run: 307 rows, 234 matches, 0.762215 coverage
- all generated artifacts are direct children of the three final leaf directories; no nested output directory remains