### PR TITLE
Fix local pipeline layer naming

### DIFF
--- a/computing/misc/antyodaya/pipeline.py
+++ b/computing/misc/antyodaya/pipeline.py
@@ -26,6 +26,7 @@ from utilities.pipelines.outputs import (
     column_dictionary,
     frame_profile,
     input_signatures,
+    resolved_scope_output_identity,
     slug,
     stable_hash,
     utc_now_text,
@@ -55,7 +56,7 @@ from utilities.constants import (
 
 CONFIG_PATH = Path(__file__).with_name("antyodaya_pipeline.yaml")
 ALGORITHM = "local-antyodaya-csv-admin-join"
-ALGORITHM_VERSION = "2.0"
+ALGORITHM_VERSION = "2.1"
 SOURCE_DEFAULTS = {
     "admin_gpkg": ADMIN_BOUNDARY_GPKG,
     "csv": ANTYODAYA_2020_CSV,
@@ -82,10 +83,6 @@ def _apply_source_defaults(config: Mapping[str, Any]) -> dict[str, Any]:
     )
     resolved["sources"] = sources
     return resolved
-
-
-def _layer_name(prefix: str, district: str | None, tehsil: str | None) -> str:
-    return f"{prefix}_{slug(district)}_{slug(tehsil)}".strip("_")
 
 
 def _cli_request(state: str, district: str, tehsil: str, sync_to_geoserver: bool = True) -> StandardRequest:
@@ -474,9 +471,19 @@ def run_antyodaya_pipeline(
     outputs = resolve_output_options(request, config)
     columns = _source_columns(config)
     output_config = config["output"]
-    layer_name = _layer_name(output_config["layer_prefix"], request.scope.district_name, request.scope.tehsil_name)
-    result_name = layer_name or f"{output_config['layer_prefix']}_{slug(request.scope.level)}"
-    output_root = _repo_path(output_config["root"]) / slug(request.scope.state_name) / slug(request.scope.district_name) / slug(request.scope.tehsil_name)
+
+    t0 = time.perf_counter()
+    admin_source = CSAdminSource(_repo_path(config["sources"]["admin_gpkg"]), table_name=config["sources"]["admin_layer"])
+    include_geometry = outputs.gpkg or request.publish.sync_to_geoserver
+    admin_selection, output_parts, result_name = resolved_scope_output_identity(
+        admin_source,
+        output_config["layer_prefix"],
+        AdminScope.from_mapping(asdict(request.scope)),
+        include_geometry=include_geometry,
+    )
+    timings["read_admin_seconds"] = round(time.perf_counter() - t0, 3)
+
+    output_root = _repo_path(output_config["root"]).joinpath(*output_parts)
     bundle = OutputBundle(
         output_root,
         result_name,
@@ -494,12 +501,6 @@ def run_antyodaya_pipeline(
         if cached:
             cached["cache_hit"] = True
             return cached
-
-    t0 = time.perf_counter()
-    admin_source = CSAdminSource(_repo_path(config["sources"]["admin_gpkg"]), table_name=config["sources"]["admin_layer"])
-    include_geometry = outputs.gpkg or request.publish.sync_to_geoserver
-    admin_selection = admin_source.read_scope(AdminScope.from_mapping(asdict(request.scope)), include_geometry=include_geometry)
-    timings["read_admin_seconds"] = round(time.perf_counter() - t0, 3)
 
     t0 = time.perf_counter()
     sidecar = _sidecar(config, columns)

--- a/computing/misc/facilities/pipeline.py
+++ b/computing/misc/facilities/pipeline.py
@@ -47,7 +47,7 @@ from utilities.pipelines.outputs import (
     frame_profile,
     input_signatures,
     mark_cached_result,
-    scope_output_identity,
+    resolved_scope_output_identity,
     slug,
     stable_hash,
     utc_now_text,
@@ -67,7 +67,7 @@ from utilities.constants import (
 
 CONFIG_PATH = Path(__file__).with_name("facilities_pipeline.yaml")
 ALGORITHM = "local-facilities-live-proximity"
-ALGORITHM_VERSION = "2.0"
+ALGORITHM_VERSION = "2.1"
 SOURCE_DEFAULTS = {
     "admin_gpkg": ADMIN_BOUNDARY_GPKG,
     "facilities_gpkg": FACILITIES_GPKG,
@@ -91,10 +91,6 @@ def _apply_source_defaults(config: Mapping[str, Any]) -> dict[str, Any]:
         sources[name] = sources.get(name) or default
     resolved["sources"] = sources
     return resolved
-
-
-def _layer_name(prefix: str, district: str | None, tehsil: str | None) -> str:
-    return f"{prefix}_{slug(district)}_{slug(tehsil)}".strip("_")
 
 
 def _cli_request(state: str, district: str, tehsil: str, sync_to_geoserver: bool = True) -> StandardRequest:
@@ -902,7 +898,17 @@ def run_facilities_pipeline(
     config = _apply_source_defaults(load_config(config_path))
     outputs = resolve_output_options(request, config)
     output_config = config["output"]
-    output_parts, layer_name = scope_output_identity(output_config["layer_prefix"], request.scope)
+
+    t0 = time.perf_counter()
+    admin_source = CSAdminSource(_repo_path(config["sources"]["admin_gpkg"]), table_name=config["sources"]["admin_layer"])
+    admin_selection, output_parts, layer_name = resolved_scope_output_identity(
+        admin_source,
+        output_config["layer_prefix"],
+        AdminScope.from_mapping(asdict(request.scope)),
+        include_geometry=True,
+    )
+    timings["read_admin_seconds"] = round(time.perf_counter() - t0, 3)
+
     output_root = _repo_path(output_config["root"]).joinpath(*output_parts)
     bundle = OutputBundle(
         output_root,
@@ -925,13 +931,9 @@ def run_facilities_pipeline(
     created_facility_indexes = _ensure_facility_indexes(config)
     timings["ensure_facility_indexes_seconds"] = round(time.perf_counter() - t0, 3)
 
-    t0 = time.perf_counter()
-    admin_source = CSAdminSource(_repo_path(config["sources"]["admin_gpkg"]), table_name=config["sources"]["admin_layer"])
-    admin_selection = admin_source.read_scope(AdminScope.from_mapping(asdict(request.scope)), include_geometry=True)
     admin_rows = admin_selection.rows
     bounds = _bbox(admin_rows)
     village_points = _village_points(admin_rows)
-    timings["read_admin_seconds"] = round(time.perf_counter() - t0, 3)
 
     t0 = time.perf_counter()
     classification = _classification(config)

--- a/computing/misc/livestocks/pipeline.py
+++ b/computing/misc/livestocks/pipeline.py
@@ -25,6 +25,7 @@ from utilities.pipelines.outputs import (
     column_dictionary,
     frame_profile,
     input_signatures,
+    resolved_scope_output_identity,
     slug,
     stable_hash,
     utc_now_text,
@@ -52,7 +53,7 @@ from utilities.constants import (
 
 CONFIG_PATH = Path(__file__).with_name("livestocks_pipeline.yaml")
 ALGORITHM = "local-livestock-csv-admin-join"
-ALGORITHM_VERSION = "2.0"
+ALGORITHM_VERSION = "2.1"
 SOURCE_DEFAULTS = {
     "admin_gpkg": ADMIN_BOUNDARY_GPKG,
     "csv": LIVESTOCK_CENSUS_20_CSV,
@@ -79,10 +80,6 @@ def _apply_source_defaults(config: Mapping[str, Any]) -> dict[str, Any]:
     )
     resolved["sources"] = sources
     return resolved
-
-
-def _layer_name(prefix: str, district: str | None, tehsil: str | None) -> str:
-    return f"{prefix}_{slug(district)}_{slug(tehsil)}".strip("_")
 
 
 def _cli_request(state: str, district: str, tehsil: str, sync_to_geoserver: bool = True) -> StandardRequest:
@@ -375,8 +372,19 @@ def run_livestocks_pipeline(
     schema = _schema(config)
     columns = _source_columns(config)
     output_config = config["output"]
-    layer_name = _layer_name(output_config["layer_prefix"], request.scope.district_name, request.scope.tehsil_name)
-    output_root = _repo_path(output_config["root"]) / slug(request.scope.state_name) / slug(request.scope.district_name) / slug(request.scope.tehsil_name)
+
+    t0 = time.perf_counter()
+    admin_source = CSAdminSource(_repo_path(config["sources"]["admin_gpkg"]), table_name=config["sources"]["admin_layer"])
+    include_geometry = outputs.gpkg or request.publish.sync_to_geoserver
+    admin_selection, output_parts, layer_name = resolved_scope_output_identity(
+        admin_source,
+        output_config["layer_prefix"],
+        AdminScope.from_mapping(asdict(request.scope)),
+        include_geometry=include_geometry,
+    )
+    timings["read_admin_seconds"] = round(time.perf_counter() - t0, 3)
+
+    output_root = _repo_path(output_config["root"]).joinpath(*output_parts)
     bundle = OutputBundle(
         output_root,
         layer_name,
@@ -394,12 +402,6 @@ def run_livestocks_pipeline(
         if cached:
             cached["cache_hit"] = True
             return cached
-
-    t0 = time.perf_counter()
-    admin_source = CSAdminSource(_repo_path(config["sources"]["admin_gpkg"]), table_name=config["sources"]["admin_layer"])
-    include_geometry = outputs.gpkg or request.publish.sync_to_geoserver
-    admin_selection = admin_source.read_scope(AdminScope.from_mapping(asdict(request.scope)), include_geometry=include_geometry)
-    timings["read_admin_seconds"] = round(time.perf_counter() - t0, 3)
 
     t0 = time.perf_counter()
     sidecar = _sidecar(config)

--- a/utilities/pipelines/outputs.py
+++ b/utilities/pipelines/outputs.py
@@ -23,6 +23,15 @@ def slug(value: Any) -> str:
     return re.sub(r"[^a-z0-9]+", "_", str(value or "").lower()).strip("_")
 
 
+def layer_slug(value: Any) -> str:
+    """Return the established Core Stack spelling for a layer-name part."""
+
+    import re
+
+    text = re.sub(r"[^a-z0-9 ,:;_-]", "", str(value or "").lower())
+    return text.replace(" ", "_")
+
+
 def utc_now_text() -> str:
     """Return an ISO UTC timestamp without microseconds."""
 
@@ -43,18 +52,47 @@ def scope_output_identity(prefix: str, scope: Any) -> tuple[tuple[str, ...], str
     state = slug(getattr(scope, "state_name", None))
     district = slug(getattr(scope, "district_name", None))
     tehsil = slug(getattr(scope, "tehsil_name", None))
+    layer_state = layer_slug(getattr(scope, "state_name", None))
+    layer_district = layer_slug(getattr(scope, "district_name", None))
+    layer_tehsil = layer_slug(getattr(scope, "tehsil_name", None))
+    layer_prefix = layer_slug(prefix)
     if level == "state":
         parts = tuple(part for part in (state,) if part)
-        return parts, "_".join(part for part in (prefix, state) if part)
+        return parts, "_".join(
+            part for part in (layer_prefix, layer_state) if part
+        )
     if level == "district":
         parts = tuple(part for part in (state, district) if part)
-        return parts, "_".join(part for part in (prefix, district) if part)
+        return parts, "_".join(
+            part for part in (layer_prefix, layer_district) if part
+        )
     if level == "village":
         village_ids = tuple(str(value) for value in (getattr(scope, "village_ids", None) or ()))
         digest = stable_hash({"village_ids": village_ids})[:10] if village_ids else "unknown"
-        return ("village", digest), f"{prefix}_village_{digest}"
+        return ("village", digest), f"{layer_prefix}_village_{digest}"
     parts = tuple(part for part in (state, district, tehsil) if part)
-    return parts, "_".join(part for part in (prefix, district, tehsil) if part)
+    return parts, "_".join(
+        part
+        for part in (layer_prefix, layer_district, layer_tehsil)
+        if part
+    )
+
+
+def resolved_scope_output_identity(
+    admin_source: Any,
+    prefix: str,
+    scope: Any,
+    *,
+    include_geometry: bool,
+) -> tuple[Any, tuple[str, ...], str]:
+    """Read a scope, then derive output identity from its canonical names."""
+
+    selection = admin_source.read_scope(
+        scope,
+        include_geometry=include_geometry,
+    )
+    output_parts, layer_name = scope_output_identity(prefix, selection.scope)
+    return selection, output_parts, layer_name
 
 
 def mark_cached_result(result: Mapping[str, Any], started: float) -> dict[str, Any]:


### PR DESCRIPTION
Local pipelines used filesystem slugs before canonical admin resolution, changing hyphens to underscores.
A shared output resolver now uses canonical admin names across Facilities, Antyodaya, and Livestock.
Validated exact 11/11 layer names, 8/8 known gaps, unchanged local output paths, and 3/3 imports.