### PR TITLE
Use internal buffer months for ET interpolation

### DIFF
--- a/computing/et_downscale/aet.py
+++ b/computing/et_downscale/aet.py
@@ -85,7 +85,6 @@ def generate_aet(cfg, region):
             "asset_suffix": asset_suffix,
             "model_aez": cfg["model_aez"],
             "model_output_scale": MODEL_OUTPUT_SCALE,
-            "interpolation": "+/-45 days for Aug-May; Jul uses Aug only; Jun uses May only",
             "description": "Bands 1-12: mean daily AET per month at 30 m; band 13: annual total AET",
         },
         band_descriptions=[f"ET_{abbr}_daily_mm" for abbr in MONTH_ABBR]
@@ -108,13 +107,13 @@ def build_aet_stack(
     ls_col = (
         ee.ImageCollection(LANDSAT_COLLECTION)
         .filterBounds(region)
-        .filterDate(start_date, start_date.advance(12, "month"))
+        .filterDate(start_date.advance(-1, "month"), start_date.advance(13, "month"))
     )
 
     if proj is None:
         proj = get_proj_30m(region, year, start_month=start_month)
 
-    months = ee.List.sequence(0, 11)
+    months = ee.List.sequence(-1, 12)
     raw_monthly = ee.ImageCollection.fromImages(
         months.map(
             lambda agri_month_idx: make_raw_monthly(

--- a/computing/et_downscale/gpp.py
+++ b/computing/et_downscale/gpp.py
@@ -88,7 +88,6 @@ def generate_gpp(cfg, region):
             "landsat_qa_mask": "QA_PIXEL bits 0-5 clear; QA_RADSAT red/NIR/terrain clear",
             "tmin_source": "GLDAS Tair_f_inst monthly minimum (K-273.15)",
             "vpd_source": "GLDAS Tair+Qair+Psurf Magnus formula",
-            "interpolation": "+/-45 days for Aug-May; Jul uses Aug only; Jun uses May only",
             "year": str(year),
             "asset_suffix": asset_suffix,
             "roi_path": cfg["roi_path"],
@@ -158,9 +157,9 @@ def build_gpp_stack(
     ls_col = (
         ee.ImageCollection(LANDSAT_COLLECTION)
         .filterBounds(region)
-        .filterDate(start_date, start_date.advance(12, "month"))
+        .filterDate(start_date.advance(-1, "month"), start_date.advance(13, "month"))
     )
-    months = ee.List.sequence(0, 11)
+    months = ee.List.sequence(-1, 12)
     raw_ndvi_monthly = ee.ImageCollection.fromImages(
         months.map(
             lambda agri_month_idx: make_raw_monthly_ndvi(
@@ -176,16 +175,16 @@ def build_gpp_stack(
         month: ee.Image(
             ndvi_monthly.filter(ee.Filter.eq("month", month)).first()
         ).select("NDVI")
-        for month in range(1, 13)
+        for month in range(0, 14)
     }
 
     gldas_col = (
         ee.ImageCollection(GLDAS_COLLECTION)
         .filterBounds(region)
-        .filterDate(start_date, start_date.advance(12, "month"))
+        .filterDate(start_date.advance(-1, "month"), start_date.advance(13, "month"))
     )
     monthly_images = []
-    for agri_month_idx in range(12):
+    for agri_month_idx in range(-1, 13):
         agri_month = agri_month_idx + 1
         monthly_images.append(
             make_raw_monthly_gpp(

--- a/computing/et_downscale/helper.py
+++ b/computing/et_downscale/helper.py
@@ -380,7 +380,7 @@ def fill_monthly_collection(
     value_band: str,
     proj: ee.Projection = None,
 ) -> ee.ImageCollection:
-    """Fill masked monthly pixels without crossing the crop-year boundary."""
+    """Fill masked monthly pixels from +/-45-day neighbours."""
 
     def normalize(img):
         img = ee.Image(img)
@@ -397,7 +397,6 @@ def fill_monthly_collection(
 
     def interpolate(img):
         img = ee.Image(img)
-        agri_month = ee.Number(img.get("month"))
         time_start = img.get("system:time_start")
         start_window = (
             ee.Date(time_start)
@@ -414,23 +413,7 @@ def fill_monthly_collection(
             .filter(ee.Filter.gte("system:time_start", start_window))
             .filter(ee.Filter.lt("system:time_start", end_window))
         )
-        july_neighbour = safe_monthly.select(value_band).filter(
-            ee.Filter.eq("month", 2)
-        )
-        june_neighbour = safe_monthly.select(value_band).filter(
-            ee.Filter.eq("month", 11)
-        )
-        neighbours = ee.ImageCollection(
-            ee.Algorithms.If(
-                agri_month.eq(1),
-                july_neighbour,
-                ee.Algorithms.If(
-                    agri_month.eq(12),
-                    june_neighbour,
-                    window_neighbours,
-                ),
-            )
-        )
+        neighbours = window_neighbours
         filled = neighbours.mean()
         out = img.select(value_band).unmask(filled)
         return (
@@ -440,7 +423,6 @@ def fill_monthly_collection(
             .set("system:time_start", time_start)
             .set("source_count", img.get("source_count"))
             .set("is_placeholder", img.get("is_placeholder"))
-            .set("interpolation_window_days", MONTHLY_INTERPOLATION_WINDOW_DAYS)
         )
 
     return safe_monthly.map(interpolate)
@@ -462,7 +444,7 @@ def monthly_collection_to_stack(
             .float()
         )
 
-    named = monthly_col.map(rename_month)
+    named = monthly_col.filter(ee.Filter.gte("month", 1)).filter(ee.Filter.lte("month", 12)).sort("month").map(rename_month)
     stack = named.toBands().clip(region)
     current_names = stack.bandNames()
     new_names = current_names.map(lambda n: ee.String(n).split("_").slice(1).join("_"))

--- a/computing/et_downscale/mai.py
+++ b/computing/et_downscale/mai.py
@@ -44,7 +44,6 @@ def generate_mai(cfg, region):
             "aet_asset": product_asset_id(cfg, "aet"),
             "pet_asset": product_asset_id(cfg, "pet"),
             "valid_data_rule": "Calculated where AET and PET are valid and PET > 0",
-            "interpolation": "+/-45 days for Aug-May; Jul uses Aug only; Jun uses May only",
             "year": str(year),
             "asset_suffix": cfg["asset_suffix"],
             "roi_path": cfg["roi_path"],

--- a/computing/et_downscale/pet.py
+++ b/computing/et_downscale/pet.py
@@ -45,7 +45,6 @@ def generate_pet(cfg, region):
             "modis_collection": modis_col_id,
             "source_scale_factor": MODIS_SCALE_FACTOR,
             "source_composite_days": MODIS_COMPOSITE_DAYS,
-            "interpolation": "+/-45 days for Aug-May; Jul uses Aug only; Jun uses May only",
             "year": str(year),
             "asset_suffix": cfg["asset_suffix"],
             "roi_path": cfg["roi_path"],
@@ -116,7 +115,7 @@ def build_pet_stack(
     """
     modis_col = ee.ImageCollection(modis_col_id).filterBounds(region)
     start_date = crop_year_start_date(year, start_month)
-    months = ee.List.sequence(0, 11)
+    months = ee.List.sequence(-1, 12)
     raw_monthly = ee.ImageCollection.fromImages(
         months.map(
             lambda agri_month_idx: _make_raw_monthly_pet(

--- a/computing/et_downscale/wue.py
+++ b/computing/et_downscale/wue.py
@@ -56,7 +56,6 @@ def generate_wue(cfg, region):
             "aet_method": "Landsat8 + GLDAS features -> Random Forest",
             "bplut_source": "MOD17 C6 BPLUT / MCD12Q1 IGBP LC_Type1",
             "valid_data_rule": "Calculated where GPP and AET are valid and AET > 0",
-            "interpolation": "+/-45 days for Aug-May; Jul uses Aug only; Jun uses May only",
             "year": str(year),
             "asset_suffix": cfg["asset_suffix"],
             "roi_path": cfg["roi_path"],


### PR DESCRIPTION
## Summary

- Calculate one internal buffer month before and after the crop year for AET, PET, and GPP monthly interpolation.
- Continue exporting only the 12 crop-year monthly bands plus the annual band.
- Remove the special July/August and June/May one-neighbour interpolation branches.
- Remove interpolation metadata from exported ET product assets.

## Validation

- Ran Python compile checks for ET downscale files.
- Ran git whitespace check on the committed diff.
- Ran Telyani tehsil GEE sanity checks without starting export tasks.
- Confirmed PET, AET, and GPP build 12 monthly output bands and 13 final export bands.
