### PR TITLE
fix: add postgresql-client-common to install script

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -923,7 +923,7 @@ function install_postgres() {
     else
         echo "Installing PostgreSQL..."
         sudo apt-get update
-        sudo apt-get install -y postgresql postgresql-contrib postgis libpq-dev
+        sudo apt-get install -y postgresql postgresql-contrib postgresql-client-common postgis libpq-dev
     fi
 
     sudo service postgresql start || sudo pg_ctlcluster 14 main start


### PR DESCRIPTION
In install.sh, the script checks whether `psql` (postgres client) is
available to determine if postgres server should be installed.
PostgreSQL ships client and server separately, so this check would
still fail even if we have run the script once (as it did for me).
This fix adds the client library to the installation script so this
installation branch of the script will only be taken once.
